### PR TITLE
Switch logging from bunyan to riverpig

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
     "moment": "^2.10.2",
     "node-uuid": "^1.4.2",
     "reconnect-core": "^1.2.0",
-    "riverpig": "^1.0.2",
+    "riverpig": "^1.1.0",
     "spdy": "^3.2.3",
     "sqlite3": "^3.1.4",
+    "through2": "^2.0.1",
     "uuid4": "^1.0.0",
     "ws": "^1.1.0"
   },
@@ -74,7 +75,6 @@
     "nodemon": "^1.8.1",
     "sinon": "^1.14.1",
     "spec-xunit-file": "0.0.1-3",
-    "supertest": "^1.1.0",
-    "through2": "^2.0.1"
+    "supertest": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "main": "src/index.js",
   "scripts": {
-    "start": "node src/index.js | bunyan",
-    "start-prof": "node --prof --logfile=${CONNECTOR_V8_LOGFILE:-v8.log} src/index.js | bunyan",
-    "start:watch": "nodemon src/index.js | bunyan",
+    "start": "node src/index.js",
+    "start-prof": "node --prof --logfile=${CONNECTOR_V8_LOGFILE:-v8.log} src/index.js",
+    "start:watch": "nodemon src/index.js",
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
     "report-coverage": "codecov",
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "bignumber.js": "^2.0.7",
-    "bunyan": "^1.8.1",
     "co": "^4.1.0",
     "co-body": "^4.0.0",
     "co-defer": "^1.0.0",
@@ -49,6 +48,7 @@
     "moment": "^2.10.2",
     "node-uuid": "^1.4.2",
     "reconnect-core": "^1.2.0",
+    "riverpig": "^1.0.2",
     "spdy": "^3.2.3",
     "sqlite3": "^3.1.4",
     "uuid4": "^1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -38,7 +38,7 @@ function listen (config, core, backend, routeBuilder, routeBroadcaster, messageR
       yield routeBroadcaster.addConfigRoutes()
       yield routeBroadcaster.reloadLocalRoutes()
     }
-    log.info('connector ready')
+    log.info('connector ready (republic attitude)')
   }).catch((err) => log.error(err))
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,8 @@ const _ = require('lodash')
 const co = require('co')
 const subscriptions = require('./models/subscriptions')
 const ilpCore = require('ilp-core')
-const log = require('./common/log')
+const logger = require('./common/log')
+const log = logger.create('app')
 
 const loadConfig = require('./lib/config')
 const makeCore = require('./lib/core')
@@ -45,7 +46,7 @@ function addPlugin (config, core, backend, routeBroadcaster, tradingPairs, id, o
   return co(function * () {
     core.addClient(id, new ilpCore.Client(Object.assign({}, options.options, {
       _plugin: require(options.plugin),
-      _log: log.create(options.plugin)
+      _log: logger.create(options.plugin)
     })))
 
     yield core.getClient(id).connect()
@@ -89,7 +90,7 @@ function createApp (config, core, backend, routeBuilder, routeBroadcaster, routi
   }
 
   if (!core) {
-    core = makeCore({config, log, routingTables})
+    core = makeCore({config, log: logger, routingTables})
   }
 
   if (!tradingPairs) {

--- a/src/common/log.js
+++ b/src/common/log.js
@@ -1,44 +1,13 @@
 'use strict'
 
-const bunyan = require('bunyan')
+const riverpig = require('riverpig')
 
 const Config = require('five-bells-shared').Config
 const envPrefix = 'CONNECTOR'
 const logLevel = Config.getEnv(envPrefix, 'LOG_LEVEL')
 
-function createLogger (name) {
-  const logger = bunyan.createLogger({
-    name: name,
-    level: logLevel,
-    stream: process.stdout
-  })
-  return logger
-}
+const defaultLogger = riverpig('connector')
 
-const defaultLogger = createLogger('connector')
-const loggers = [defaultLogger]
+defaultLogger.create = riverpig
 
-function createChildLogger (module) {
-  const logger = defaultLogger.child({
-    module: module
-  })
-  loggers.push(logger)
-  return logger
-}
-
-// For unit testing
-function setOutputStream (outputStream) {
-  loggers.forEach((logger) => {
-    logger.streams = []
-    logger.addStream({
-      type: 'stream',
-      stream: outputStream,
-      level: logLevel
-    })
-    logger.currentOutput = outputStream
-  })
-}
-
-defaultLogger.create = createChildLogger
-defaultLogger.setOutputStream = setOutputStream
 module.exports = defaultLogger

--- a/src/common/log.js
+++ b/src/common/log.js
@@ -2,12 +2,23 @@
 
 const riverpig = require('riverpig')
 
-const Config = require('five-bells-shared').Config
-const envPrefix = 'CONNECTOR'
-const logLevel = Config.getEnv(envPrefix, 'LOG_LEVEL')
+const logStream = require('through2')()
+logStream.pipe(process.stdout)
 
-const defaultLogger = riverpig('connector')
+const create = (namespace) => {
+  return riverpig(namespace, {
+    stream: logStream
+  })
+}
 
-defaultLogger.create = riverpig
+let outputStream = process.stdout
+const setOutputStream = (newOutputStream) => {
+  logStream.unpipe(outputStream)
+  logStream.pipe(newOutputStream)
+  outputStream = newOutputStream
+}
 
-module.exports = defaultLogger
+module.exports = {
+  create,
+  setOutputStream
+}

--- a/test/helpers/log.js
+++ b/test/helpers/log.js
@@ -1,26 +1,24 @@
 'use strict'
 
-/* global beforeEach, afterEach */
-
 // This helper captures log output for each test and prints it in case of
 // failure. This means that a successful test run will only print mocha's output
 // whereas a failed run will include more information.
 
 const through = require('through2')
-const format = require('bunyan-format')({outputMode: 'short'})
 
 module.exports = function (logger) {
+  let buffer
   beforeEach(function () {
-    const buffer = through()
+    buffer = through()
     buffer.pause()
     logger.setOutputStream(buffer)
   })
 
   afterEach(function () {
-    const buffer = logger.currentOutput
     if (this.currentTest.state !== 'passed') {
-      buffer.pipe(format)
+      buffer.pipe(process.stdout, { end: false })
+      buffer.end()
     }
-    logger.setOutputStream(format)
+    logger.setOutputStream(process.stdout)
   })
 }

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -11,12 +11,16 @@ const RouteBroadcaster = require('ilp-connector')._test.RouteBroadcaster
 const makeCore = require('../src/lib/core')
 const log = require('../src/common').log
 const appHelper = require('./helpers/app')
+const logger = require('ilp-connector')._test.logger
+const logHelper = require('./helpers/log')
 
 const ledgerA = 'cad-ledger.'
 const ledgerB = 'usd-ledger.'
 const ledgerC = 'eur-ledger.'
 
 describe('RouteBroadcaster', function () {
+  logHelper(logger)
+
   beforeEach(function * () {
     appHelper.create(this)
 

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -23,9 +23,9 @@ const markB = 'eur-ledger.mark'
 const maryB = 'eur-ledger.mary'
 
 describe('RouteBuilder', function () {
+  logHelper(logger)
   beforeEach(function * () {
     appHelper.create(this)
-    logHelper(logger)
 
     this.infoCache = {
       get: function * (ledger) {


### PR DESCRIPTION
Bunyan is causing issues during development due to the separate CLI transformer process. Riverpig is a cleaner, simpler logger. As a dependency it is 10x smaller than bunyan.
