### PR TITLE
chore: switch to integration-test-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
     "report-coverage": "codecov",
-    "integration": "integration all",
+    "integration": "integration-loader && integration all",
     "bump": "version-bump"
   },
   "engines": {
@@ -66,7 +66,7 @@
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
-    "five-bells-integration-test": "^4.1.1",
+    "five-bells-integration-test-loader": "^1.0.0",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.2",
     "mock-require": "^1.3.0",
@@ -76,5 +76,11 @@
     "sinon": "^1.14.1",
     "spec-xunit-file": "0.0.1-3",
     "supertest": "^1.1.0"
+  },
+  "config": {
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
+    }
   }
 }


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* interledgerjs/five-bells-ledger@b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader