### PR TITLE
fix: allow BACKEND to be an external module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ npm start
 * `CONNECTOR_ROUTE_BROADCAST_INTERVAL` (default: `30000`) the frequency at which the connector broadcasts its routes to adjacent connectors.
 * `CONNECTOR_ROUTE_CLEANUP_INTERVAL` (default: `1000`) the frequency at which the connector checks for expired routes.
 * `CONNECTOR_ROUTE_EXPIRY` (default: `45000`) the maximum age of a route.
+* `CONNECTOR_BACKEND` (default: `'fixerio'`) the backend used to determine rates. This can either be a module name from `src/backends/` or a different module that will be `require()`ed by the connector.
 
 ## Running with Docker
 
@@ -139,3 +140,48 @@ Breaking down that command:
 
 The connector will facilitate an interledger payment upon receiving a notification for a transfer in which it is credited. That "source" transfer must have a `ilp_header` in its credit's `memo` that specifies the payment's destination and amount.
 As soon as the source transfer is prepared, the connector will authorize the debits from its account(s) on the destination ledger.
+
+## Backend
+
+### Class: Backend
+#### Methods
+
+| `new` | [**Backend**](#new-backend) ( opts ) |
+| | [**connect**](#connect) ( ) `⇒ Promise.<null>` |
+| | [**getQuote**](#getQuote) ( params ) `⇒ Promise.<Quote>` |
+
+##### new Backend
+<code>new Backend( **opts** : Object )</code>
+
+###### Parameters
+| Name | Type | Description |
+|:--|:--|:--|
+| `opts` | `Object` | |
+| `opts.backendUri` | `URI` | (see `CONNECTOR_BACKEND_URI`) |
+| `opts.currencyWithLedgerPairs` | `TradingPairs` | currency pairs supported by the connector |
+| `opts.infoCache` | `InfoCache` | a cache of ledger metadata |
+| `opts.spread` | `Number` | (see `CONNECTOR_FX_SPREAD`) |
+
+#### connect
+<code>backend.connect() ⇒ Promise.&lt;null></code>
+
+#### getQuote
+<code>backend.getQuote( **params** : [QuoteParams](#class-quoteparams) ) ⇒ Promise.&lt;Quote></code>
+
+### Class: QuoteParams
+###### Fields
+| Type | Name | Description |
+|:--|:--|:--|
+| `String` | `source_ledger` | The URI of the source ledger |
+| `String` | `destination_ledger` | The URI of the destination ledger |
+| `String`/`Integer`/`BigNumber` | `source_amount` | The amount of the source asset we want to send (either this or the `destination_amount` must be set)
+| `String`/`Integer`/`BigNumber` | `destination_amount` | The amount of the destination asset we want to send (either this or the `source_amount` must be set) |
+
+### Class: Quote
+###### Fields
+| Type | Name | Description |
+|:--|:--|:--|
+| `String` | `source_ledger` | The URI of the source ledger |
+| `String` | `destination_ledger` | The URI of the destination ledger |
+| `String` | `source_amount` | The amount of the source asset we want to send |
+| `String` | `destination_amount` | The amount of the destination asset we want to send |

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node-uuid": "^1.4.2",
     "reconnect-core": "^1.2.0",
     "riverpig": "^1.1.0",
-    "spdy": "^3.2.3",
     "sqlite3": "^3.1.4",
     "through2": "^2.0.1",
     "uuid4": "^1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -165,14 +165,17 @@ function createApp (config, core, backend, routeBuilder, routeBroadcaster, routi
 }
 
 function getBackend (backend) {
+  if (moduleExists('./backends/' + backend)) return require('./backends/' + backend)
+  if (moduleExists(backend)) return require(backend)
+  throw new Error('Backend not found at "' + backend + '" or "/backends/' + backend + '"')
+}
+
+function moduleExists (path) {
   try {
-    return require('./backends/' + backend)
+    require.resolve(path)
+    return true
   } catch (err) {
-    try {
-      return require(backend)
-    } catch (err) {
-      throw new Error('Backend not found at "' + backend + '" or "/backends/' + backend + '"')
-    }
+    return false
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -98,12 +98,7 @@ function createApp (config, core, backend, routeBuilder, routeBroadcaster, routi
   }
 
   if (!backend) {
-    const Backend = require('./backends/' + config.get('backend'))
-    if (!Backend) {
-      throw new Error('Backend not found. The backend ' +
-        'module specified by CONNECTOR_BACKEND was not found in /backends')
-    }
-
+    const Backend = getBackend(config.get('backend'))
     backend = new Backend({
       currencyWithLedgerPairs: tradingPairs,
       backendUri: config.get('backendUri'),
@@ -166,6 +161,18 @@ function createApp (config, core, backend, routeBuilder, routeBroadcaster, routi
     listen: _.partial(listen, config, core, backend, routeBuilder, routeBroadcaster, messageRouter, tradingPairs),
     addPlugin: _.partial(addPlugin, config, core, backend, routeBroadcaster, tradingPairs),
     removePlugin: _.partial(removePlugin, config, core, backend, routingTables, tradingPairs)
+  }
+}
+
+function getBackend (backend) {
+  try {
+    return require('./backends/' + backend)
+  } catch (err) {
+    try {
+      return require(backend)
+    } catch (err) {
+      throw new Error('Backend not found at "' + backend + '" or "/backends/' + backend + '"')
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/interledgerjs/ilp-connector/issues/249

This doesn't address the issue that Backends should supply route curves.