### PR TITLE
Fix: allow the connector to send on negative balance

### DIFF
--- a/src/models/quote.js
+++ b/src/models/quote.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const UnacceptableExpiryError = require('../errors/unacceptable-expiry-error')
-const UnacceptableAmountError = require('../errors/unacceptable-amount-error')
 
 function * makeQuoteQuery (params) {
   return {
@@ -38,13 +37,6 @@ function * validateExpiries (sourceExpiryDuration, destinationExpiryDuration, mi
   }
 }
 
-function * validateBalance (balanceCache, ledger, amount) {
-  const balance = yield balanceCache.get(ledger)
-  if (balance.lessThan(amount)) {
-    throw new UnacceptableAmountError('Insufficient liquidity in market maker account')
-  }
-}
-
 /**
  * @param {Object} params
  * @param {String} params.source_address
@@ -72,8 +64,6 @@ function * getQuote (params, config, routeBuilder, balanceCache) {
     quote.sourceExpiryDuration,
     quote.destinationExpiryDuration,
     quote.minMessageWindow, config)
-  // Check the balance of the next ledger (_not_ the final ledger).
-  yield validateBalance(balanceCache, quote.nextLedger, quote.destinationAmount)
 
   return {
     source_ledger: quote.sourceLedger,

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -272,19 +272,16 @@ describe('Quotes', function () {
       }).catch(done)
     })
 
-    it('should return a UnacceptableAmountError for insufficient liquidity', function (done) {
+    it('should not return an Error for insufficient liquidity', function (done) {
       this.messageRouter.getQuote({
         destination_amount: '150001',
         source_address: 'eur-ledger.alice',
         destination_address: 'usd-ledger.bob',
         destination_expiry_duration: '10'
-      }).then((quote) => {
-        throw new Error()
-      }).catch((err) => {
-        expect(err.name).to.equal('UnacceptableAmountError')
-        expect(err.message).to.equal('Insufficient liquidity in market maker account')
+      }).then(() => {
         done()
-      }).catch(done)
+      })
+        .catch(done)
     })
 
     it('should return a ExternalError when unable to get precision from source_address', function (done) {
@@ -329,7 +326,7 @@ describe('Quotes', function () {
       }).catch(done)
     })
 
-    it('should return a ExternalError when unable to get balance from ledger', function (done) {
+    it('should not return an Error when unable to get balance from ledger', function (done) {
       this.infoCache.reset()
       nock.cleanAll()
       this.core.getPlugin('eur-ledger.')
@@ -344,12 +341,10 @@ describe('Quotes', function () {
         source_address: 'eur-ledger.alice',
         destination_address: 'usd-ledger.bob',
         destination_expiry_duration: '10'
-      }).then((quote) => {
-        throw new Error()
-      }).catch((err) => {
-        expect(err.name).to.equal('ExternalError')
+      }).then(() => {
         done()
-      }).catch(done)
+      })
+        .catch(done)
     })
 
     it('should return a valid Quote object', function (done) {


### PR DESCRIPTION
Validating that the balance is greater than the sending amount will cause errors in many cases. First, if an account has a minimum allowed balance less than zero, it will cause the connector to break if its balance ever goes negative. Checking a minimum balance also would cause problems; some ledgers (such as trust-lines) may not have a static minimum balance.

If the connector's transaction is rejected by the ledger due to low balance, it will still cancel the previous transaction.