### PR TITLE
fix: disable plugin.connect() timeout

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -49,7 +49,7 @@ function addPlugin (config, core, backend, routeBroadcaster, tradingPairs, id, o
       _log: logger.createRaw(options.plugin)
     })))
 
-    yield core.getClient(id).connect()
+    yield core.getClient(id).connect({timeout: 0})
 
     if (tradesTo) {
       tradingPairs.addPairs(tradesTo.map((e) => [options.currency + '@' + id, e]))

--- a/src/models/subscriptions.js
+++ b/src/models/subscriptions.js
@@ -60,7 +60,8 @@ function * subscribeLedger (ledgerPrefix, core, config) {
   log.info('subscribing to ' + ledgerPrefix)
   const client = core.getClient(ledgerPrefix)
 
-  yield client.connect()
+  // Disable connect() timeout
+  yield client.connect({timeout: 0})
 }
 
 module.exports = {


### PR DESCRIPTION
Disable the timeout introduced by https://github.com/interledgerjs/ilp-plugin-bells/pull/74.

The timeout should be disabled because the ledger may just not have been started yet (see https://github.com/interledgerjs/ilp-connector/issues/248).