### PR TITLE
Chore: remove plugin-virtual dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "five-bells-shared": "^20.0.0",
     "ilp-core": "~9.1.3",
     "ilp-plugin-bells": "^9.0.0",
-    "ilp-plugin-virtual": "^7.0.0",
     "ilp-routing": "~5.1.1",
     "lodash": "^4.6.1",
     "moment": "^2.10.2",


### PR DESCRIPTION
plugin-virtual isn't used anywhere in the connector directly. Having an outdated version routinely breaks the ILP Kit when there are updates.