### PR TITLE
Fix: allow long strings in plugin store

### DIFF
--- a/src/lib/pluginStore.js
+++ b/src/lib/pluginStore.js
@@ -9,8 +9,8 @@ class PluginStore {
     this.db = new Database(uri)
 
     this.Store = this.db.define('plugin_store_' + name, {
-      key: { type: Sequelize.STRING, primaryKey: true },
-      value: Sequelize.STRING
+      key: { type: Sequelize.TEXT, primaryKey: true },
+      value: Sequelize.TEXT
     })
 
     this.connected = false

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -30,4 +30,10 @@ describe('PluginStore', function () {
       done()
     }).catch((err) => { console.error(err) })
   })
+
+  it('should store a long string', function * () {
+    const str = ('long string. another ').repeat(1000)
+    yield this.obj.put('k', str)
+    assert.equal(yield this.obj.get('k'), str)
+  })
 })


### PR DESCRIPTION
The `Sequelize.STRING` type is limited to 255 characters.