### PR TITLE
Fix: add and remove peers along with plugins

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,13 +65,15 @@ function addPlugin (config, core, backend, routeBroadcaster, tradingPairs, id, o
     }
 
     yield routeBroadcaster.reloadLocalRoutes()
+    yield routeBroadcaster._crawlClient(core.getClient(id))
   })
 }
 
-function removePlugin (config, core, backend, routingTables, tradingPairs, id) {
+function removePlugin (config, core, backend, routingTables, routeBroadcaster, tradingPairs, id) {
   return co(function * () {
     tradingPairs.removeAll(id)
     routingTables.removeLedger(id)
+    routeBroadcaster.depeerLedger(id)
     yield core.removeClient(id).disconnect()
   })
 }
@@ -161,7 +163,7 @@ function createApp (config, core, backend, routeBuilder, routeBroadcaster, routi
   return {
     listen: _.partial(listen, config, core, backend, routeBuilder, routeBroadcaster, messageRouter, tradingPairs),
     addPlugin: _.partial(addPlugin, config, core, backend, routeBroadcaster, tradingPairs),
-    removePlugin: _.partial(removePlugin, config, core, backend, routingTables, tradingPairs)
+    removePlugin: _.partial(removePlugin, config, core, backend, routingTables, routeBroadcaster, tradingPairs)
   }
 }
 

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -122,6 +122,10 @@ class RouteBroadcaster {
     }
   }
 
+  depeerLedger (prefix) {
+    delete this.peersByLedger[prefix]
+  }
+
   * reloadLocalRoutes () {
     const localRoutes = yield this._getLocalRoutes()
     yield this.routingTables.addLocalRoutes(this.infoCache, localRoutes)

--- a/test/modifyPluginSpec.js
+++ b/test/modifyPluginSpec.js
@@ -70,6 +70,18 @@ describe('Modify Plugins', function () {
         destination_expiry_duration: '1.001'
       })
     })
+
+    it('should get peers on the added ledger', function * () {
+      yield this.app.addPlugin('eur-ledger-2.', {
+        currency: 'EUR',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          prefix: 'eur-ledger-2.'
+        }
+      })
+
+      assert.isTrue(this.routeBroadcaster.peersByLedger['eur-ledger-2.']['mark'])
+    })
   })
 
   describe('removePlugin', function () {
@@ -77,7 +89,10 @@ describe('Modify Plugins', function () {
       yield this.app.addPlugin('eur-ledger-2.', {
         currency: 'EUR',
         plugin: 'ilp-plugin-mock',
-        options: {}
+        prefix: 'eur-ledger-2.',
+        options: {
+          prefix: 'eur-ledger-2.'
+        }
       })
     })
 
@@ -108,6 +123,12 @@ describe('Modify Plugins', function () {
         expect(err.name).to.equal('AssetsNotTradedError')
         expect(err.message).to.match(/This connector does not support the given asset pair/)
       })
+    })
+
+    it('should depeer the removed ledger', function * () {
+      yield this.app.removePlugin('eur-ledger-2.')
+
+      assert.isNotOk(this.routeBroadcaster.peersByLedger['eur-ledger-2.'])
     })
   })
 })


### PR DESCRIPTION
The current `addPlugin` and `removePlugin` functions don't properly add/remove peers.