### PR TITLE
feat: relay data field

### DIFF
--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -166,7 +166,7 @@ class RouteBuilder {
       direction: 'outgoing',
       account: nextHop.destinationCreditAccount,
       amount: nextHop.destinationAmount,
-      data: { ilp_header: ilpHeader },
+      data: sourceTransfer.data,
       noteToSelf,
       executionCondition: sourceTransfer.executionCondition,
       cancellationCondition: sourceTransfer.cancellationCondition,

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -146,6 +146,33 @@ describe('Payments', function () {
     })
   })
 
+  it('passes on the data (including but not limited to the ILP header)', function * () {
+    const sendSpy = sinon.spy(this.mockPlugin2, 'sendTransfer')
+    const packet = {
+      ilp_header: {
+        account: 'mock.test2.bob',
+        amount: '50'
+      },
+      extra_headers: [{
+        foo: 'bar'
+      }]
+    }
+    yield this.mockPlugin1.emitAsync('incoming_prepare', {
+      id: '5857d460-2a46-4545-8311-1539d99e78e8',
+      direction: 'incoming',
+      ledger: 'mock.test1.',
+      amount: '100',
+      executionCondition: 'cc:0:',
+      expiresAt: (new Date(START_DATE + 1000)).toISOString(),
+      data: packet
+    })
+
+    sinon.assert.calledOnce(sendSpy)
+    sinon.assert.calledWithMatch(sendSpy, {
+      data: packet
+    })
+  })
+
   it('supports optimistic mode', function * () {
     const sendSpy = sinon.spy(this.mockPlugin2, 'sendTransfer')
     yield this.mockPlugin1.emitAsync('incoming_transfer', {


### PR DESCRIPTION
the connector should relay fields in the data aside from the ilp_header so that we can include other headers as well