### PR TITLE
chore: ignore unkown methods instead of throwing

### DIFF
--- a/src/lib/message-router.js
+++ b/src/lib/message-router.js
@@ -96,7 +96,7 @@ MessageRouter.prototype._handleRequest = function * (request, sender) {
     return
   }
 
-  throw new InvalidBodyError('Invalid method')
+  log.debug('ignoring unkown request method', request.method)
 }
 
 /**


### PR DESCRIPTION
Connector shouldn't throw an exception if it receives requests that it's not familiar with. Other components listening to accounts might be trying to handle them.