### PR TITLE
fix: add connectors from config, even if not in ledger info

### DIFF
--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -184,11 +184,30 @@ class RouteBroadcaster {
       // Don't broadcast routes to ourselves.
       if (localAccount === connector) continue
       if (this.autoloadPeers || this.defaultPeers.indexOf(connector) !== -1) {
-        this.peersByLedger[prefix] = this.peersByLedger[prefix] || {}
-        this.peersByLedger[prefix][connector] = true
-        log.info('adding peer ' + connector + ' via ledger ' + prefix)
+        this._addPeer(prefix, connector)
       }
     }
+
+    // Add peers from config if their prefixes match the ledger,
+    // even if they are not returned in the ledger info
+    for (const connectorAddress of this.defaultPeers) {
+      if (connectorAddress.indexOf(prefix) === 0) {
+        const connector = connectorAddress.replace(prefix, '')
+        this._addPeer(prefix, connector)
+      }
+    }
+  }
+
+  _addPeer (prefix, connector) {
+    if (!this.peersByLedger[prefix]) {
+      this.peersByLedger[prefix] = {}
+    }
+    if (this.peersByLedger[prefix][connector]) {
+      // don't log duplicates
+      return
+    }
+    this.peersByLedger[prefix][connector] = true
+    log.info('adding peer ' + connector + ' via ledger ' + prefix)
   }
 
   depeerLedger (prefix) {

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -80,7 +80,7 @@ describe('RouteBroadcaster', function () {
       destination_scale: 2
     }])
 
-    this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.ledgers, {
+    this.config = {
       tradingPairs: [
         [ledgerA, ledgerB],
         [ledgerB, ledgerA]
@@ -91,7 +91,9 @@ describe('RouteBroadcaster', function () {
       ledgerCredentials,
       configRoutes,
       routeExpiry: 1234
-    })
+    }
+
+    this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.ledgers, this.config)
 
     this.tables.addRoute({
       source_ledger: ledgerB,
@@ -107,6 +109,16 @@ describe('RouteBroadcaster', function () {
 
   afterEach(function () {
     delete process.env.BACKEND
+  })
+
+  describe('crawl', function () {
+    it('loads peers from CONNECTOR_PEERS even if they are not returned in the ledger info', function * () {
+      this.config.peers.push('eur-ledger.margery')
+      this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.ledgers, this.config)
+      yield this.broadcaster.crawl()
+      console.log(this.broadcaster.peersByLedger)
+      assert(this.broadcaster.peersByLedger['eur-ledger.']['margery'])
+    })
   })
 
   describe('addConfigRoutes', function () {


### PR DESCRIPTION
right now only connectors that are returned in the ledger info will be added as peers. this change makes it so all connectors listed in CONNECTOR_PEERS will be added, whether or not the ledger plugin knows about them