### PR TITLE
Feat: add dump() to plugin store

### DIFF
--- a/src/lib/pluginStore.js
+++ b/src/lib/pluginStore.js
@@ -62,6 +62,19 @@ class PluginStore {
       return null
     })
   }
+
+  dump () {
+    return this.connect().then(() => {
+      return this.Store.findAll({
+        attributes: [ 'key', 'value' ]
+      })
+    }).then((values) => {
+      return values.reduce((aggregator, entry) => {
+        aggregator[entry.key] = entry.value
+        return aggregator
+      }, {})
+    })
+  }
 }
 
 module.exports = PluginStore

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -37,6 +37,20 @@ describe('PluginStore', function () {
     assert.equal(yield this.obj.get('k'), str)
   })
 
+  it('should dump the store with dump()', function * () {
+    yield this.obj.put('k', 'v')
+    yield this.obj.put('a', 'b')
+    yield this.obj.put('c', 'd')
+    yield this.obj.put('e', 'f')
+
+    assert.deepEqual(yield this.obj.dump(), {
+      k: 'v',
+      a: 'b',
+      c: 'd',
+      e: 'f'
+    })
+  })
+
   it('should not create a store with an invalid name', function * () {
     const name = ('"; drop table "Users; --')
     try {


### PR DESCRIPTION
Adds a `dump()` method that returns the entire plugin store as an in-memory object. Required by https://github.com/interledgerjs/ilp-plugin-virtual/pull/57 to resolve race conditions with the store.