### PR TITLE
fix: use config routes for any input/output amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ilp-core": "^14.0.0",
     "ilp-packet": "~1.1.1",
     "ilp-plugin-bells": "^13.0.0",
-    "ilp-routing": "~7.0.2",
+    "ilp-routing": "~7.1.0",
     "lodash": "^4.6.1",
     "moment": "^2.10.2",
     "riverpig": "^1.1.0",

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -241,7 +241,7 @@ class RouteBroadcaster {
 
       const route = new Route(
         // use a 1:1 curve as a placeholder (it will be overwritten by a remote quote)
-        [ [0, 0], [1, 1] ],
+        [ [0, 0], [Number.MAX_VALUE, Number.MAX_VALUE] ],
         // the second ledger is inserted to make sure this the hop to the
         // connectorLedger is not considered final.
         [ connectorLedger, targetPrefix ],
@@ -250,7 +250,8 @@ class RouteBroadcaster {
           targetPrefix: targetPrefix }
       )
 
-      this.routingTables.addRoute(route)
+      // set the noExpire option to true when adding config routes
+      this.routingTables.addRoute(route, true)
     }
 
     // returns a promise in order to be similar to reloadLocalRoutes()

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -62,9 +62,9 @@ class RoutingTables {
     }
   }
 
-  addRoute (route) {
-    this.localTables.addRoute(route)
-    return this.publicTables.addRoute(route)
+  addRoute (route, noExpire) {
+    this.localTables.addRoute(route, noExpire)
+    return this.publicTables.addRoute(route, noExpire)
   }
 
   findBestHopForSourceAmount (sourceLedger, destinationLedger, sourceAmount) {


### PR DESCRIPTION
Fix is based on an old version of connector so we can backport it.

Config routes were using the curve `[ [0, 0], [1, 1] ]`, which was causing any source/dest amounts above 1 to fail. Because the curve only defines what's in the domain but remote quotes determine the actual rate, it now should use `[ [0, 0], [Number.MAX_VALUE, Number.MAX_VALUE] ]`.