### PR TITLE
Fix: escape the dash in plugin store name regex

### DIFF
--- a/src/lib/pluginStore.js
+++ b/src/lib/pluginStore.js
@@ -8,7 +8,7 @@ class PluginStore {
     this.name = name
     this.db = new Database(uri)
 
-    if (!name.match(/^[A-Za-z0-9_-~.]+$/)) {
+    if (!name.match(/^[A-Za-z0-9_\-~.]+$/)) {
       throw new Error('"' + name + '" includes forbidden characters.')
     }
 

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -46,4 +46,10 @@ describe('PluginStore', function () {
       assert.match(e.message, new RegExp(name))
     }
   })
+
+  it('should create a store with dashes in the name', function * () {
+    const name = ('a-name-with-dashes')
+    const store = new PluginStore('sqlite://:memory:', name)
+    assert.isOk(store)
+  })
 })


### PR DESCRIPTION
Dash is a special character in the regex square brackets