### PR TITLE
feat: liquidity routing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -104,7 +104,8 @@ function createApp (config, ledgers, backend, routeBuilder, routeBroadcaster, ro
       currencyWithLedgerPairs: ledgers.getPairs(),
       backendUri: config.get('backendUri'),
       spread: config.get('fxSpread'),
-      getInfo: (ledger) => ledgers.getPlugin(ledger).getInfo()
+      getInfo: (ledger) => ledgers.getPlugin(ledger).getInfo(),
+      getBalance: (ledger) => ledgers.getPlugin(ledger).getBalance()
     })
   }
 

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -37,7 +37,8 @@ exports.create = function (context) {
     currencyWithLedgerPairs: tradingPairs,
     backendUri: config.get('backendUri'),
     spread: config.get('fxSpread'),
-    getInfo: (ledger) => ledgers.getPlugin(ledger).getInfo()
+    getInfo: (ledger) => ledgers.getPlugin(ledger).getInfo(),
+    getBalance: (ledger) => ledgers.getPlugin(ledger).getBalance()
   })
   ledgers.addFromCredentialsConfig(config.get('ledgerCredentials'))
   ledgers.setPairs(config.get('tradingPairs'))

--- a/test/mocks/mockPlugin.js
+++ b/test/mocks/mockPlugin.js
@@ -49,8 +49,8 @@ class MockPlugin extends EventEmitter {
 
   * _handleNotification () { }
 
-  * getBalance () {
-    return '123.456'
+  getBalance () {
+    return Promise.resolve('123.456')
   }
 
   getInfo () {

--- a/test/modifyPluginSpec.js
+++ b/test/modifyPluginSpec.js
@@ -26,7 +26,7 @@ describe('Modify Plugins', function () {
     const testLedgers = ['cad-ledger.', 'usd-ledger.', 'eur-ledger.', 'cny-ledger.']
     _.map(testLedgers, (ledgerUri) => {
       this.ledgers.getPlugin(ledgerUri).getBalance =
-        function * () { return '150000' }
+        function () { return Promise.resolve('150000') }
     })
 
     // Reset before and after just in case a test wants to change the precision.

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -266,7 +266,7 @@ describe('Quotes', function () {
         destination_ledger: 'usd-ledger.',
         destination_amount: '1056024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
         destination_expiry_duration: '5',
-        liquidity_curve: [ [1000, 0], [1000000000000, 1057081598942.9185] ]
+        liquidity_curve: [ [999.9999999999999, 0], [1000000000000, 1057081598942.9186] ]
       })
     })
 
@@ -291,7 +291,7 @@ describe('Quotes', function () {
         destination_ledger: 'usd-ledger.',
         destination_amount: '10560', // EUR/USD Rate of 1.0592 - .2% spread - slippage
         destination_expiry_duration: '5',
-        liquidity_curve: [ [10.000000000000002, 0], [1000000000000, 1057081599989.4292] ]
+        liquidity_curve: [ [10, 0], [1000000000000, 1057081599989.4293] ]
       })
     })
 
@@ -346,7 +346,7 @@ describe('Quotes', function () {
         destination_ledger: 'usd-ledger.',
         destination_amount: '1056024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
         destination_expiry_duration: '5',
-        liquidity_curve: [ [1000, 0], [1000000000000, 1057081598942.9185] ]
+        liquidity_curve: [ [999.9999999999999, 0], [1000000000000, 1057081598942.9186] ]
       })
     })
 
@@ -365,7 +365,7 @@ describe('Quotes', function () {
         destination_ledger: 'usd-ledger.',
         destination_amount: '1000000',
         destination_expiry_duration: '5',
-        liquidity_curve: [ [946.0007628550152, 0], [1000000000946.0007, 1057081600000] ]
+        liquidity_curve: [ [946.0007628550151, 0], [1000000000946.0007, 1057081600000.0001] ]
       })
     })
 
@@ -383,7 +383,7 @@ describe('Quotes', function () {
         destination_ledger: 'usd-ledger.',
         destination_amount: '1056024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
         destination_expiry_duration: '5',
-        liquidity_curve: [ [1000, 0], [1000000000000, 1057081598942.9185] ]
+        liquidity_curve: [ [999.9999999999999, 0], [1000000000000, 1057081598942.9186] ]
       })
     })
 
@@ -401,7 +401,7 @@ describe('Quotes', function () {
         destination_ledger: 'eur-ledger.',
         destination_amount: '941278', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
         destination_expiry_duration: '5',
-        liquidity_curve: [ [1000, 0], [1000000000000, 942220542864.4259] ]
+        liquidity_curve: [ [1000.0000000000001, 0], [1000000000000, 942220542864.426] ]
       })
     })
 

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -23,6 +23,10 @@ const markA = 'usd-ledger.mark'
 const markB = 'eur-ledger.mark'
 const maryB = 'eur-ledger.mary'
 
+const mockPlugin = require('./mocks/mockPlugin')
+const mock = require('mock-require')
+mock('ilp-plugin-mock', mockPlugin)
+
 describe('RouteBuilder', function () {
   logHelper(logger)
   beforeEach(function * () {

--- a/test/routingTablesSpec.js
+++ b/test/routingTablesSpec.js
@@ -6,6 +6,10 @@ const appHelper = require('./helpers/app')
 const logHelper = require('./helpers/log')
 const logger = require('../src/common/log')
 
+const mockPlugin = require('./mocks/mockPlugin')
+const mock = require('mock-require')
+mock('ilp-plugin-mock', mockPlugin)
+
 describe('RoutingTables', function () {
   logHelper(logger)
 

--- a/test/subscriptionSpec.js
+++ b/test/subscriptionSpec.js
@@ -12,6 +12,10 @@ const wsHelper = require('./helpers/ws')
 const subscriptions = require('../src/models/subscriptions')
 const sinon = require('sinon')
 
+const mockPlugin = require('./mocks/mockPlugin')
+const mock = require('mock-require')
+mock('ilp-plugin-mock', mockPlugin)
+
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 
 const env = _.cloneDeep(process.env)

--- a/test/tradingPairsSpec.js
+++ b/test/tradingPairsSpec.js
@@ -5,6 +5,10 @@ const TradingPairs = require('../src/lib/trading-pairs')
 const logHelper = require('./helpers/log')
 const logger = require('../src/common/log')
 
+const mockPlugin = require('./mocks/mockPlugin')
+const mock = require('mock-require')
+mock('ilp-plugin-mock', mockPlugin)
+
 describe('TradingPairs', function () {
   logHelper(logger)
 


### PR DESCRIPTION
When prepending a trustline as a hop, clip the liquidity curve to the maximum inbound transfer, so `plugin.maxBalance()-plugin.getBalance()`. This should help avoid a lot of the failed payments we're currently seeing when trying to use ilp-kit to pay each other back for lunch.