### PR TITLE
feat: use secret to generate transfer ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ npm start
 * `CONNECTOR_ROUTE_CLEANUP_INTERVAL` (default: `1000`) the frequency at which the connector checks for expired routes.
 * `CONNECTOR_ROUTE_EXPIRY` (default: `45000`) the maximum age of a route.
 * `CONNECTOR_BACKEND` (default: `'fixerio'`) the backend used to determine rates. This can either be a module name from `src/backends/` or a different module that will be `require()`ed by the connector.
+* `CONNECTOR_SECRET` (default: 32 random bytes) base64url-encoded 32-byte secret used by the connector to deterministically randomize transfer IDs
+* `CONNECTOR_UNWISE_USE_SAME_TRANSFER_ID` (default: false, obviously) use the same transfer id for the destination transfer as the source transfer. If ledgers enforce transfer ID uniqueness (as they SHOULD), this means that someone can squat on an ID on the destination ledger and make this connector seem unreliable
 
 ## Running with Docker
 

--- a/src/app.js
+++ b/src/app.js
@@ -125,7 +125,9 @@ function createApp (config, ledgers, backend, quoter, routeBuilder, routeBroadca
       {
         minMessageWindow: config.expiry.minMessageWindow,
         maxHoldTime: config.expiry.maxHoldTime,
-        slippage: config.slippage
+        slippage: config.slippage,
+        secret: config.secret,
+        unwiseUseSameTransferId: config.unwiseUseSameTransferId
       }
     )
   }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,6 +6,7 @@ const Utils = require('../lib/utils')
 const _ = require('lodash')
 const logger = require('../common/log')
 const log = logger.create('config')
+const crypto = require('crypto')
 
 const envPrefix = 'CONNECTOR'
 
@@ -202,6 +203,14 @@ function getLocalConfig () {
   // }
   const ledgerCredentials = parseCredentials()
 
+  // The secret is used to generate destination transfer IDs
+  // that cannot be guessed and squatted on by others
+  const secretString = Config.getEnv(envPrefix, 'SECRET')
+  const secret = secretString
+    ? Buffer.from(secretString, 'base64')
+    : crypto.randomBytes(32)
+  const unwiseUseSameTransferId = Config.castBool(Config.getEnv(envPrefix, 'UNWISE_USE_SAME_TRANSFER_ID'))
+
   return {
     backend,
     configRoutes,
@@ -218,7 +227,9 @@ function getLocalConfig () {
     routeExpiry,
     autoloadPeers,
     peers,
-    databaseUri
+    databaseUri,
+    secret,
+    unwiseUseSameTransferId
   }
 }
 

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -33,6 +33,13 @@ describe('ConnectorConfig', function () {
       process.env = _.cloneDeep(env)
     })
 
+    it('should generate a secret if one is not provided', function * () {
+      delete process.env.CONNECTOR_SECRET
+      const config = loadConnectorConfig()
+      expect(Buffer.isBuffer(config.secret)).to.be.true
+      expect(config.secret).to.have.length(32)
+    })
+
     it('should auto-generate pairs', function * () {
       const config = loadConnectorConfig()
       expect(config.get('tradingPairs')).to.deep.equal([[

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -24,6 +24,8 @@ exports.create = function (context) {
   }
   process.env.CONNECTOR_DEBUG_REPLY_NOTIFICATIONS = 'true'
 
+  process.env.CONNECTOR_SECRET = 'VafuntVJRw6YzDTs4IgIU1IPJACywtgUUQJHh1u018w='
+
   const config = loadConfig()
   const tradingPairs = new TradingPairs(config.get('tradingPairs'))
   const routingTables = new RoutingTables({
@@ -50,7 +52,8 @@ exports.create = function (context) {
     {
       minMessageWindow: config.expiry.minMessageWindow,
       maxHoldTime: config.expiry.maxHoldTime,
-      slippage: config.slippage
+      slippage: config.slippage,
+      secret: config.secret
     }
   )
   const routeBroadcaster = new RouteBroadcaster(routingTables, backend, ledgers, {


### PR DESCRIPTION
also allow the connector to be configured such that it will use the same transfer id for the destination as the source (even though this is not recommended)