### PR TITLE
fix: use strings when generating curves

### DIFF
--- a/src/backends/fixerio/index.js
+++ b/src/backends/fixerio/index.js
@@ -116,13 +116,13 @@ class FixerIoBackend {
     if (sourceInfo.maxBalance !== undefined) {
       let balanceIn = yield this.getBalance(params.source_ledger)
       let maxAmountIn = new BigNumber(sourceInfo.maxBalance).minus(balanceIn)
-      limit = [ maxAmountIn.toNumber(), maxAmountIn.times(rate).toNumber() ]
+      limit = [ maxAmountIn.toString(), maxAmountIn.times(rate).toString() ]
     }
     if (destinationInfo.minBalance !== undefined) {
       let balanceOut = yield this.getBalance(params.destination_ledger)
       let maxAmountOut = new BigNumber(balanceOut).minus(destinationInfo.minBalance)
       if (limit === undefined || maxAmountOut.lessThan(limit[1])) {
-        limit = [ maxAmountOut.div(rate).toNumber(), maxAmountOut.toNumber() ]
+        limit = [ maxAmountOut.div(rate).toString(), maxAmountOut.toString() ]
       }
     }
 

--- a/src/backends/one-to-one.js
+++ b/src/backends/one-to-one.js
@@ -66,13 +66,13 @@ class OneToOneBackend {
     if (sourceInfo.maxBalance !== undefined) {
       let balanceIn = yield this.getBalance(params.source_ledger)
       let maxAmountIn = new BigNumber(sourceInfo.maxBalance).minus(balanceIn)
-      limit = [ maxAmountIn.toNumber(), maxAmountIn.times(rate).toNumber() ]
+      limit = [ maxAmountIn.toString(), maxAmountIn.times(rate).toString() ]
     }
     if (destinationInfo.minBalance !== undefined) {
       let balanceOut = yield this.getBalance(params.destination_ledger)
       let maxAmountOut = new BigNumber(balanceOut).minus(destinationInfo.minBalance)
       if (limit === undefined || maxAmountOut.lessThan(limit[1])) {
-        limit = [ maxAmountOut.div(rate).toNumber(), maxAmountOut.toNumber() ]
+        limit = [ maxAmountOut.div(rate).toString(), maxAmountOut.toString() ]
       }
     }
 


### PR DESCRIPTION
Using numbers can cause:

    ERROR Couldn't add the peer to the connector { BigNumber Error: lt() number type has more than 15 significant digits: 9671611521766.432
      at raise (/var/app/ilp-kit/node_modules/bignumber.js/bignumber.js:1198:25)
      at new BigNumber (/var/app/ilp-kit/node_modules/bignumber.js/bignumber.js:262:21)
      at BigNumber.P.lessThan.P.lt (/var/app/ilp-kit/node_modules/bignumber.js/bignumber.js:1572:35)
      at FixerIoBackend.getCurve (/var/app/ilp-kit/node_modules/ilp-connector/src/backends/fixerio/index.js:124:47)
      at getCurve.next (<anonymous>)
      at onFulfilled (/var/app/ilp-kit/node_modules/co/index.js:65:19)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:169:7) name: 'BigNumber Error' }