### PR TITLE
fix: listen() should return a Promise

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@ function listen (config, ledgers, backend, routeBuilder, routeBroadcaster, messa
 
   // Start a coroutine that connects to the backend and
   // subscribes to all the ledgers in the background
-  co(function * () {
+  return co(function * () {
     try {
       yield backend.connect()
     } catch (error) {

--- a/src/lib/message-router.js
+++ b/src/lib/message-router.js
@@ -37,7 +37,10 @@ MessageRouter.prototype.handleRequest = function (requestMessage) {
     return Promise.reject(new Error('Invalid request message'))
   }
   return co.wrap(this._handleRequest).call(this, requestMessage).catch((err) => {
-    if (!(err instanceof IlpError)) throw err
+    if (!(err instanceof IlpError)) {
+      log.warn('handleRequest error', err.stack)
+      throw err
+    }
     return {
       ledger: requestMessage.ledger,
       from: requestMessage.to,


### PR DESCRIPTION
* `ilp-connector.listen()` needs to return a Promise so that ilp-kit knows when the connector is ready.
* Also adds a log line for when `handleRequest()` fails.