### PR TITLE
fix: fix connector_first race condition

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -46,12 +46,13 @@ function listen (config, ledgers, backend, routeBuilder, routeBroadcaster, messa
       yield routeBroadcaster.addConfigRoutes()
     }
 
-    if (!allLedgersConnected) {
+    if (allLedgersConnected) {
+      log.info('connector ready (republic attitude)')
+    } else {
       ledgers.connect({timeout: Infinity})
         .then(() => routeBroadcaster.reloadLocalRoutes())
-        .then(() => log.info('all ledgers connected'))
+        .then(() => log.info('connector ready (republic attitude)'))
     }
-    log.info('connector ready (republic attitude)')
   }).catch((err) => log.error(err))
 }
 

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -224,9 +224,10 @@ class RouteBroadcaster {
     delete this.peersByLedger[prefix]
   }
 
-  * reloadLocalRoutes () {
-    const localRoutes = yield this._getLocalRoutes()
-    this.routingTables.addLocalRoutes(this.ledgers, localRoutes)
+  reloadLocalRoutes () {
+    return this._getLocalRoutes().then((localRoutes) => {
+      this.routingTables.addLocalRoutes(this.ledgers, localRoutes)
+    })
   }
 
   _getLocalRoutes () {


### PR DESCRIPTION
If the connector started before the ledgers, "connector ready" could print before both plugins were connected. The test would start, but there would be no routes.

With this patch, the connector will only print "connector ready" when all plugins are connected, so the test will pass.