### PR TITLE
fix: return T04: Insufficient Liquidity

### DIFF
--- a/src/lib/ilp-errors.js
+++ b/src/lib/ilp-errors.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// ILP Error Codes (see RFC-0003 for more details).
+const errors = {
+  F00_Bad_Request: {code: 'F00', name: 'Bad Request'},
+  F01_Invalid_Packet: {code: 'F01', name: 'Invalid Packet'},
+  F02_Unreachable: {code: 'F02', name: 'Unreachable'},
+  F03_Invalid_Amount: {code: 'F03', name: 'Invalid Amount'},
+  F04_Insufficient_Destination_Amount: {code: 'F04', name: 'Insufficient Destination Amount'},
+  F05_Wrong_Condition: {code: 'F05', name: 'Wrong Condition'},
+  F06_Unexpected_Payment: {code: 'F06', name: 'Unexpected Payment'},
+  F07_Cannot_Receive: {code: 'F07', name: 'Cannot Receive'},
+  F99_Application_Error: {code: 'F99', name: 'Application Error'},
+
+  T00_Internal_Error: {code: 'T00', name: 'Internal Error'},
+  T01_Ledger_Unreachable: {code: 'T01', name: 'Ledger Unreachable'},
+  T02_Ledger_Busy: {code: 'T02', name: 'Ledger Busy'},
+  T03_Connector_Busy: {code: 'T03', name: 'Connector Busy'},
+  T04_Insufficient_Liquidity: {code: 'T04', name: 'Insufficient Liquidity'},
+  T05_Rate_Limited: {code: 'T05', name: 'Rate Limited'},
+  T99_Application_Error: {code: 'T99', name: 'Application Error'},
+
+  R00_Transfer_Timed_Out: {code: 'R00', name: 'Transfer Timed Out'},
+  R01_Insufficient_Source_Amount: {code: 'R01', name: 'Insufficient Source Amount'},
+  R02_Insufficient_Timeout: {code: 'R02', name: 'Insufficient Timeout'},
+  R99_Application_Error: {code: 'R99', name: 'Application Error'}
+}
+
+function makeError (base, extra) {
+  return Object.assign({}, base, extra)
+}
+
+for (const key in errors) {
+  exports[key] = makeError.bind(null, errors[key])
+}

--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -2,6 +2,7 @@
 const _ = require('lodash')
 const BigNumber = require('bignumber.js')
 const packet = require('ilp-packet')
+const ilpErrors = require('./ilp-errors')
 const NoRouteFoundError = require('../errors/no-route-found-error')
 const UnacceptableExpiryError = require('../errors/unacceptable-expiry-error')
 const UnacceptableAmountError = require('../errors/unacceptable-amount-error')
@@ -147,22 +148,18 @@ class RouteBuilder {
       'sourceLedger=%s sourceAmount=%s ilpPacket=%s',
       sourceTransfer.ledger, sourceTransfer.amount, sourceTransfer.ilp)
     if (!sourceTransfer.ilp) {
-      throw new IncomingTransferError({
-        code: 'S01',
-        name: 'Invalid Packet',
+      throw new IncomingTransferError(ilpErrors.F01_Invalid_Packet({
         message: 'source transfer is missing "ilp"'
-      })
+      }))
     }
     let ilpPacket
     try {
       ilpPacket = packet.deserializeIlpPayment(Buffer.from(sourceTransfer.ilp, 'base64'))
     } catch (err) {
       log.debug('error parsing ILP packet: ' + sourceTransfer.ilp)
-      throw new IncomingTransferError({
-        code: 'S01',
-        name: 'Invalid Packet',
+      throw new IncomingTransferError(ilpErrors.F01_Invalid_Packet({
         message: 'source transfer has invalid ILP packet'
-      })
+      }))
     }
     const destinationAddress = ilpPacket.account
     const myAddress = this.ledgers.getPlugin(sourceTransfer.ledger).getAccount()
@@ -183,11 +180,9 @@ class RouteBuilder {
       sourceLedger, ilpPacket.account, sourceTransfer.amount)
     if (!nextHop) {
       log.info('could not find quote for source transfer: ' + JSON.stringify(sourceTransfer))
-      throw new IncomingTransferError({
-        code: 'S02',
-        name: 'Unreachable',
+      throw new IncomingTransferError(ilpErrors.F02_Unreachable({
         message: 'No route found from: ' + sourceLedger + ' to: ' + ilpPacket.account
-      })
+      }))
     }
     this._verifyLedgerIsConnected(nextHop.destinationLedger)
 
@@ -197,11 +192,9 @@ class RouteBuilder {
       // As long as the fxSpread > slippage, the connector won't lose money.
       const expectedFinalAmount = new BigNumber(ilpPacket.amount).times(1 - this.slippage)
       if (expectedFinalAmount.greaterThan(nextHop.finalAmount)) {
-        throw new IncomingTransferError({
-          code: 'R01',
-          name: 'Insufficient Source Amount',
+        throw new IncomingTransferError(ilpErrors.R01_Insufficient_Source_Amount({
           message: 'Payment rate does not match the rate currently offered'
-        })
+        }))
       }
       // TODO: Verify atomic mode notaries are trusted
       // TODO: Verify expiry is acceptable

--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -198,7 +198,7 @@ class RouteBuilder {
       const expectedFinalAmount = new BigNumber(ilpPacket.amount).times(1 - this.slippage)
       if (expectedFinalAmount.greaterThan(nextHop.finalAmount)) {
         throw new IncomingTransferError({
-          code: 'R02',
+          code: 'R01',
           name: 'Insufficient Source Amount',
           message: 'Payment rate does not match the rate currently offered'
         })

--- a/src/models/payments.js
+++ b/src/models/payments.js
@@ -25,6 +25,10 @@ function * settle (sourceTransfer, destinationTransfer, config, ledgers) {
           code: 'S00',
           name: 'Bad Request',
           message: 'destination transfer failed: ' + err.message
+        } : (err.name === 'NotAcceptedError') ? {
+          code: 'T04',
+          name: 'Insufficient Liquidity',
+          message: 'destination transfer failed: ' + err.message
         } : {
           code: 'T01',
           name: 'Ledger Unreachable',

--- a/src/models/payments.js
+++ b/src/models/payments.js
@@ -4,6 +4,7 @@ const testPaymentExpiry = require('../lib/testPaymentExpiry')
 const log = require('../common').log.create('payments')
 const executeSourceTransfer = require('../lib/executeSourceTransfer')
 const validator = require('../lib/validate')
+const ilpErrors = require('../lib/ilp-errors')
 const IncomingTransferError = require('../errors/incoming-transfer-error')
 
 function * validateExpiry (sourceTransfer, destinationTransfer, config) {
@@ -21,19 +22,13 @@ function * settle (sourceTransfer, destinationTransfer, config, ledgers) {
     .sendTransfer(destinationTransfer)
     .catch((err) => {
       const rejectionMessage =
-        (err.name === 'InvalidFieldsError' || err.name === 'DuplicateIdError') ? {
-          code: 'S00',
-          name: 'Bad Request',
-          message: 'destination transfer failed: ' + err.message
-        } : (err.name === 'NotAcceptedError') ? {
-          code: 'T04',
-          name: 'Insufficient Liquidity',
-          message: 'destination transfer failed: ' + err.message
-        } : {
-          code: 'T01',
-          name: 'Ledger Unreachable',
-          message: 'destination transfer failed: ' + err.message
-        }
+          (err.name === 'InvalidFieldsError' || err.name === 'DuplicateIdError')
+        ? ilpErrors.F00_Bad_Request({message: 'destination transfer failed: ' + err.message})
+        : (err.name === 'InsufficientBalanceError')
+        ? ilpErrors.T04_Insufficient_Liquidity({message: 'destination transfer failed: ' + err.message})
+        : (err.name === 'AccountNotFoundError')
+        ? ilpErrors.F02_Unreachable({message: 'destination transfer failed: ' + err.message})
+        : ilpErrors.T01_Ledger_Unreachable({message: 'destination transfer failed: ' + err.message})
       return ledgers.getPlugin(sourceTransfer.ledger)
         .rejectIncomingTransfer(sourceTransfer.id, Object.assign({
           triggered_by: ledgers.getPlugin(destinationTransfer.ledger).getAccount(),

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -388,7 +388,7 @@ describe('Payments', function () {
     const rejectSpy = sinon.spy(this.mockPlugin1, 'rejectIncomingTransfer')
     this.mockPlugin2.sendTransfer = function () {
       return Promise.reject({
-        name: 'NotAcceptedError',
+        name: 'InsufficientBalanceError',
         message: 'Sender has insufficient funds.'
       })
     }
@@ -434,7 +434,7 @@ describe('Payments', function () {
     })
     sinon.assert.calledOnce(rejectSpy)
     sinon.assert.calledWith(rejectSpy, '5857d460-2a46-4545-8311-1539d99e78e8', sinon.match({
-      code: 'S01',
+      code: 'F01',
       name: 'Invalid Packet',
       message: 'source transfer has invalid ILP packet',
       triggered_by: 'mock.test1.bob',
@@ -458,7 +458,7 @@ describe('Payments', function () {
     })
     sinon.assert.calledOnce(rejectSpy)
     sinon.assert.calledWith(rejectSpy, '5857d460-2a46-4545-8311-1539d99e78e8', sinon.match({
-      code: 'R03',
+      code: 'R02',
       name: 'Insufficient Timeout',
       message: 'Transfer has already expired',
       triggered_by: 'mock.test1.bob',
@@ -482,7 +482,7 @@ describe('Payments', function () {
     })
     sinon.assert.calledOnce(rejectSpy)
     sinon.assert.calledWith(rejectSpy, '5857d460-2a46-4545-8311-1539d99e78e8', sinon.match({
-      code: 'R03',
+      code: 'R02',
       name: 'Insufficient Timeout',
       message: 'Not enough time to send payment',
       triggered_by: 'mock.test1.bob',

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -384,6 +384,43 @@ describe('Payments', function () {
     assert(false)
   })
 
+  it('rejects the source transfer if settlement fails with insufficient liquidity', function * () {
+    const rejectSpy = sinon.spy(this.mockPlugin1, 'rejectIncomingTransfer')
+    this.mockPlugin2.sendTransfer = function () {
+      return Promise.reject({
+        name: 'NotAcceptedError',
+        message: 'Sender has insufficient funds.'
+      })
+    }
+
+    try {
+      yield this.mockPlugin1.emitAsync('incoming_prepare', {
+        id: '5857d460-2a46-4545-8311-1539d99e78e8',
+        direction: 'incoming',
+        ledger: 'mock.test1.',
+        amount: '100',
+        executionCondition: 'ni:///sha-256;I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk?fpt=preimage-sha-256&cost=6',
+        expiresAt: (new Date(START_DATE + 1000)).toISOString(),
+        ilp: packet.serializeIlpPayment({
+          account: 'mock.test2.bob',
+          amount: '50'
+        }).toString('base64')
+      })
+    } catch (err) {
+      assert.equal(err.message, 'Sender has insufficient funds.')
+      sinon.assert.calledOnce(rejectSpy)
+      sinon.assert.calledWith(rejectSpy, '5857d460-2a46-4545-8311-1539d99e78e8', sinon.match({
+        code: 'T04',
+        name: 'Insufficient Liquidity',
+        message: 'destination transfer failed: Sender has insufficient funds.',
+        triggered_by: 'mock.test2.bob',
+        additional_info: {}
+      }))
+      return
+    }
+    assert(false)
+  })
+
   it('rejects with Invalid Packet if the incoming transfer\'s ILP packet isn\'t valid', function * () {
     const rejectSpy = sinon.spy(this.mockPlugin1, 'rejectIncomingTransfer')
     yield this.mockPlugin1.emitAsync('incoming_transfer', {


### PR DESCRIPTION
* Translate a plugin's `NotAcceptedError` on `sendTransfer()` to `T04: Insufficient Liquidity`.
* Also, "Insufficient Source Amount" is `R01`, not `R02`.

Related to https://github.com/interledgerjs/ilp-kit/issues/400

Depends on https://github.com/interledgerjs/five-bells-integration-test/pull/86 and https://github.com/interledgerjs/ilp-plugin-bells/pull/154