### PR TITLE
fix: greedy forwarding

### DIFF
--- a/src/lib/quoter.js
+++ b/src/lib/quoter.js
@@ -142,30 +142,6 @@ class Quoter {
   }
 
   /**
-   * @param {IlpAddress} sourceLedger
-   * @param {IlpAddress} destination
-   * @param {Amount} sourceAmount
-   * @returns {Object}
-   */
-  * findBestPathForSourceAmount (sourceLedger, destination, sourceAmount) {
-    const quote = yield this.quoteBySourceAmount({
-      sourceAccount: sourceLedger,
-      destinationAccount: destination,
-      sourceAmount: sourceAmount,
-      destinationHoldDuration: 10 // dummy value, only used if a remote quote is needed
-    })
-    if (!quote) return
-    const headRoute = this.localTables.getLocalPairRoute(sourceLedger, quote.route.nextLedger)
-    const headCurve = headRoute.curve
-    return {
-      destinationLedger: quote.route.nextLedger,
-      destinationCreditAccount: quote.hop,
-      destinationAmount: headCurve.amountAt(sourceAmount).toString(),
-      finalAmount: quote.liquidityCurve.amountAt(sourceAmount).toString()
-    }
-  }
-
-  /**
    * Note that this function, like most of the ilp-connector code, uses the terms
    * source, destination, and final, to refer to what we would normally call
    * incoming, outgoing, and destination.

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -194,7 +194,7 @@ describe('RouteBuilder', function () {
         ledger: ledgerA,
         direction: 'incoming',
         account: aliceA,
-        amount: '98', // 98 ⇒ 49 = 50 * (1 - slippage)
+        amount: '99', // 99  * (1 - slippage) = 100 ⇒ 50
         ilp: ilpPacket
       })
       assert.equal(destinationTransfer.ilp, ilpPacket)


### PR DESCRIPTION
When the incoming amount is higher than expected, don't forward this difference on to the next connector; instead, always pay as little as possible (based on the curve from next to final).

cc @emschwartz @justmoon 