### PR TITLE
Enable self-pairs by default

### DIFF
--- a/src/lib/executeSourceTransfer.js
+++ b/src/lib/executeSourceTransfer.js
@@ -44,7 +44,8 @@ function * executeSourceTransfer (destinationTransfer, fulfillment, ledgers, bac
     return Promise.resolve(plugin.fulfillCondition(sourceTransferID, fulfillment))
       .catch(function (err) {
         if (shouldRetry(err)) {
-          log.debug(`Resubmitting fulfillment for source transfer ${sourceTransferID}.`)
+          const errInfo = (typeof err === 'object' && err.stack) ? err.stack : String(err)
+          log.debug(`Resubmitting fulfillment for source transfer ${sourceTransferID} after error ${errInfo}`)
           retry(err)
         }
       })

--- a/src/lib/ledgers.js
+++ b/src/lib/ledgers.js
@@ -124,7 +124,6 @@ class Ledgers extends EventEmitter {
     if (!tradesFrom && !tradesTo) {
       const newLedger = creds.currency + '@' + ledgerPrefix
       for (let otherLedgerPrefix of this._ledgers.keys()) {
-        if (ledgerPrefix === otherLedgerPrefix) continue
         const currency = this._ledgers.get(otherLedgerPrefix).currency
         const otherLedger = currency + '@' + otherLedgerPrefix
         this._pairs.add(newLedger, otherLedger)

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -7,16 +7,19 @@ const crypto = require('crypto')
  *
  * Example:
  *   getPairs ([1, 2, 3, 4])
- *   // => [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 4 ],
- *           [ 2, 1 ], [ 3, 1 ], [ 4, 1 ], [ 3, 2 ], [ 4, 2 ], [ 4, 3 ] ]
+ *   => [ [ 1, 1 ], [ 1, 2 ], [ 2, 1 ], [ 1, 3 ], [ 3, 1 ], [ 1, 4 ], [ 4, 1 ],
+ *        [ 2, 2 ], [ 2, 3 ], [ 3, 2 ], [ 2, 4 ], [ 4, 2 ],
+ *        [ 3, 3 ], [ 3, 4 ], [ 4, 3 ],
+ *        [ 4, 4 ] ]
  *
  * @param {array} arr Input array
  * @return {array[]} Possible pairs
  */
 function getPairs (arr) {
-  return arr.reduce((prev, cur, i) => (
-    [].concat.apply(prev, arr.slice(i + 1).map((val) => [[cur, val], [val, cur]]))
-  ), [])
+  return arr.reduce((prev, cur, i) => {
+    const combinations = arr.slice(i + 1).map(val => [[cur, val], [val, cur]])
+    return prev.concat(Array.prototype.concat.apply([[cur, cur]], combinations))
+  }, [])
 }
 
 /**

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -44,6 +44,9 @@ describe('ConnectorConfig', function () {
       const config = loadConnectorConfig()
       expect(config.get('tradingPairs')).to.deep.equal([[
         'USD@usd-ledger.',
+        'USD@usd-ledger.'
+      ], [
+        'USD@usd-ledger.',
         'EUR@eur-ledger.'
       ], [
         'EUR@eur-ledger.',
@@ -56,10 +59,16 @@ describe('ConnectorConfig', function () {
         'USD@usd-ledger.'
       ], [
         'EUR@eur-ledger.',
+        'EUR@eur-ledger.'
+      ], [
+        'EUR@eur-ledger.',
         'AUD@aud-ledger.'
       ], [
         'AUD@aud-ledger.',
         'EUR@eur-ledger.'
+      ], [
+        'AUD@aud-ledger.',
+        'AUD@aud-ledger.'
       ]])
     })
 


### PR DESCRIPTION
Previously, the connector did not add pairs that would allow it to route a payment coming from ledger x back to that same ledger. And why would it? Ledgers were perfectly capable of directly routing that payment.

However, since the Interledger enlightenment, we may want to have the connector act as a ledger replacement. This mostly works, but for performance, we would like one plugin be able to represent multiple clients. Once again, this mostly works out of the box, except that the connector does not know how to deliver a payment if it's destination ledger is the same as its source.

This PR changes the connector such that it creates pairs for each ledger to itself by default.