### PR TITLE
Forwarded by should be an array

### DIFF
--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -515,7 +515,7 @@ describe('Payments', function () {
         name: 'Error 1',
         message: 'error 1',
         triggered_by: 'foo',
-        forwarded_by: 'mock.test2.bob',
+        forwarded_by: ['mock.test2.bob'],
         additional_info: {}
       })
     })
@@ -544,7 +544,7 @@ describe('Payments', function () {
         name: 'Error 1',
         message: 'error 1',
         triggered_by: 'foo',
-        forwarded_by: 'mock.test2.bob',
+        forwarded_by: ['mock.test2.bob'],
         additional_info: {}
       })
     })


### PR DESCRIPTION
Tests currently fail, because of interledger/rfcs#332, see [RejectionMessage.json](https://github.com/interledgerjs/five-bells-shared/blob/96c77d5ad34efffd2e6d7004eb57cafb214a079c/schemas/RejectionMessage.json)