### PR TITLE
Use best rate when ILP packet amount is zero

### DIFF
--- a/src/lib/quoter.js
+++ b/src/lib/quoter.js
@@ -141,6 +141,18 @@ class Quoter {
     }, liquidityQuote)
   }
 
+  async findBestPathForSourceAmount (sourceLedger, destination, sourceAmount) {
+    const hop = this.localTables.findBestHopForSourceAmount(
+      sourceLedger, destination, sourceAmount)
+
+    return {
+      destinationLedger: hop.bestRoute.nextLedger,
+      destinationCreditAccount: hop.bestRoute.isLocal ? destination : hop.bestHop,
+      sourceAmount: sourceAmount.toString(),
+      destinationAmount: hop.bestRoute.curve.amountAt(sourceAmount).toString()
+    }
+  }
+
   /**
    * Note that this function, like most of the ilp-connector code, uses the terms
    * source, destination, and final, to refer to what we would normally call
@@ -172,8 +184,7 @@ class Quoter {
       destinationLedger: quote.route.nextLedger,
       destinationCreditAccount: quote.hop,
       sourceAmount: quote.sourceAmount,
-      destinationAmount: headCurve.amountAt(quote.sourceAmount).toString(),
-      finalAmount: quote.liquidityCurve.amountAt(quote.sourceAmount).toString()
+      destinationAmount: headCurve.amountAt(quote.sourceAmount).toString()
     }
   }
 }

--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -176,8 +176,12 @@ class RouteBuilder {
       ilpPacket.account, ilpPacket.amount)
 
     const sourceLedger = sourceTransfer.ledger
-    const nextHop = await this.quoter.findBestPathForFinalAmount(
-      sourceLedger, ilpPacket.account, ilpPacket.amount)
+
+    // If the ILP amount field is zero, it means we should forward the maximum
+    // we are willing to.
+    const nextHop = (ilpPacket.amount === '0')
+      ? await this.quoter.findBestPathForSourceAmount(sourceLedger, ilpPacket.account, sourceTransfer.amount)
+      : await this.quoter.findBestPathForFinalAmount(sourceLedger, ilpPacket.account, ilpPacket.amount)
     if (!nextHop) {
       log.info('could not find quote for source transfer: ' + JSON.stringify(sourceTransfer))
       throw new IncomingTransferError(ilpErrors.F02_Unreachable({

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -280,6 +280,37 @@ describe('Payments', function () {
     })
   })
 
+  it('uses best rate when ilp packet amount = 0', async function () {
+    const sendSpy = sinon.spy(this.mockPlugin2, 'sendTransfer')
+    await this.mockPlugin1.emitAsync('incoming_prepare', {
+      id: '5857d460-2a46-4545-8311-1539d99e78e8',
+      direction: 'incoming',
+      ledger: 'mock.test1.',
+      amount: '100',
+      executionCondition: 'ni:///sha-256;I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk?fpt=preimage-sha-256&cost=6',
+      expiresAt: (new Date(START_DATE + 1000)).toISOString(),
+      ilp: packet.serializeIlpPayment({
+        account: 'mock.test2.bob',
+        amount: '0'
+      }).toString('base64')
+    })
+
+    sinon.assert.calledOnce(sendSpy)
+    sinon.assert.calledWithMatch(sendSpy, {
+      direction: 'outgoing',
+      ledger: 'mock.test2.',
+      to: 'mock.test2.bob',
+      amount: '94',
+      executionCondition: 'ni:///sha-256;I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk?fpt=preimage-sha-256&cost=6',
+      expiresAt: (new Date(START_DATE)).toISOString(),
+      noteToSelf: {
+        source_transfer_id: '5857d460-2a46-4545-8311-1539d99e78e8',
+        source_transfer_ledger: 'mock.test1.',
+        source_transfer_amount: '100'
+      }
+    })
+  })
+
   it('supports optimistic mode', async function () {
     const sendSpy = sinon.spy(this.mockPlugin2, 'sendTransfer')
     await this.mockPlugin1.emitAsync('incoming_transfer', {

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -168,6 +168,23 @@ describe('RouteBuilder', function () {
       assert.deepEqual(destinationTransfer.ilp, ilpPacket)
     })
 
+    it('uses best rate when ilp packet amount = 0', async function () {
+      const ilpPacket = packet.serializeIlpPayment({
+        account: bobB,
+        amount: '0'
+      }).toString('base64')
+      const destinationTransfer = await this.builder.getDestinationTransfer({
+        id: 'fd7ecefd-8eb8-4e16-b7c8-b67d9d6995f5',
+        ledger: ledgerA,
+        direction: 'incoming',
+        account: aliceA,
+        amount: '100',
+        ilp: ilpPacket
+      })
+      assert.deepEqual(destinationTransfer.amount, '50')
+      assert.deepEqual(destinationTransfer.to, 'eur-ledger.bob')
+    })
+
     it('throws "Insufficient Source Amount" when the amount is too low', async function () {
       const ilpPacket = packet.serializeIlpPayment({
         account: bobB,


### PR DESCRIPTION
As proposed in interledger/rfcs#313.

@michielbdejong [suggested](https://github.com/interledger/rfcs/issues/312#issuecomment-339663215) that overloading the existing packet format is a bad idea. In a general sense, I agree. As a practical matter, this patch is (as you can see below) very simple, breaks none of the existing tests (and doesn't break any existing ILP use cases) and allows us to build modern chunked/streaming payment transport layer protocols on our existing reference implementation. (Plan is that @emschwartz will start to work on back-porting the "ILP3" transport layer into the ilp module this week.)

I think the ultimate goal should be a cleaned-up ILPv2/BestEffort packet, where the amount is removed, see interledger/rfcs#323. However, I like the idea of experimenting with the new transport layer protocols right away and building this new packet using the experience gathered from that work. So I would urge us to adopt @adrianhopebailie's proposal (specifically the part about taking amount = 0 to mean best-effort) for now.

See also the sister PR for ilp-connector-shard: interledgerjs/ilp-connector-shard#4

