### PR TITLE
feat: increase default max hold time

### DIFF
--- a/src/schemas/Config.json
+++ b/src/schemas/Config.json
@@ -179,7 +179,7 @@
     "maxHoldTime": {
       "description": "Maximum duration (in milliseconds) the connector is willing to place funds on hold while waiting for the outcome of a transaction.",
       "type": "integer",
-      "default": 10000
+      "default": 30000
     },
     "routeBroadcastEnabled": {
       "description": "Whether to broadcast known routes.",


### PR DESCRIPTION
Since the default `minMessageWindow` is a generous 1000ms, a `maxHoldTime` of only 10s implies a maximum number of hops of nine. This PR increases the default to 30s, which corresponds to about 30s hops which should be plenty. If 30s turns out to be too high due to the free option problem, we can adjust it down again.