### PR TITLE
fix: add prepack build hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "npm run schema-to-tsd && npm run compile-ts",
     "schema-to-tsd": "node scripts/build_schema_types",
     "compile-ts": "tsc --project .",
+    "prepack": "npm run build",
     "prepare": "npm run build",
     "lint": "tslint --project .",
     "test": "nyc mocha",


### PR DESCRIPTION
The npm "prepack" hook runs when installing the repo from git (e.g. when the integration tests are run in CircleCI). This is necessary because the built javascript files aren't committed, only the typescript.

This + https://github.com/interledgerjs/five-bells-integration-test/pull/93 will fix https://github.com/interledgerjs/ilp-connector/pull/416 integration tests.