### PR TITLE
feat: extend admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ See also: <https://github.com/interledger/rfcs/issues/330#issuecomment-348750488
 
 #### Built-in: rateLimit
 
-* Pipelines: incomingData, incomingMoney, outgoingData, outgoingMoney
+* Pipelines: `incomingData`, `incomingMoney`, `outgoingData`, `outgoingMoney`
 
 Reduces the maximum number of total requests incoming from or outgoing to any account.
 
@@ -525,33 +525,39 @@ Used for basic rate limiting and to help with DoS.
 
 #### Built-in: maxPacketAmount
 
-* Pipelines: incomingData, outgoingData
+* Pipelines: `incomingData`, `outgoingData`
 
 Rejects packets with an amount greater than the specified value.
 
 #### Built-in: throughput
 
-* Pipelines: incomingData, outgoingData
+* Pipelines: `incomingData`, `outgoingData`
 
 Limits the throughput for a given account. Throughput is the amount of money transferred per time.
 
 #### Built-in: balance
 
-* Pipelines: incomingData, incomingMoney, outgoingData, outgoingMoney
+* Pipelines: `startup`, `incomingData`, `incomingMoney`, `outgoingData`, `outgoingMoney`
 
 Tracks the balance of a given account from the perspective of the connector. This is also the subsystem that triggers settlements.
 
 #### Built-in: validateFulfillment
 
-* Pipelines: outgoingData
+* Pipelines: `outgoingData`
 
 Validates fulfillments in incoming ILP fulfill responses. If the fulfillment is invalid, it converts the fulfillment into a rejection.
 
 #### Built-in: expire
 
-* Pipelines: outgoingData
+* Pipelines: `outgoingData`
 
 Expires outgoing ILP packets at their designated `expiresAt` time. Returns a rejection when this occurs.
+
+#### Built-in: stats
+
+* Pipelines: `incomingData`, `incomingMoney`, `outgoingData`, `outgoingMoney`
+
+Tracks throughput by account. Results are accessible through the admin API.
 
 ### Extensibility: Backends
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "compile-ts": "tsc --project .",
     "prepack": "npm run build",
     "prepare": "npm run build",
-    "lint": "tslint --project .",
+    "lint": "tslint --project . && eslint test/",
     "test": "nyc mocha",
     "report-coverage": "nyc report --reporter=json && codecov -f coverage/*.json",
     "integration": "integration-loader && integration all",

--- a/src/middlewares/stats.ts
+++ b/src/middlewares/stats.ts
@@ -1,0 +1,66 @@
+import * as IlpPacket from 'ilp-packet'
+import {
+  Middleware,
+  MiddlewareCallback,
+  MiddlewareMethod,
+  MiddlewareServices,
+  MiddlewareStats,
+  Pipelines
+} from '../types/middleware'
+
+export default class StatsMiddleware implements Middleware {
+  private stats: MiddlewareStats
+
+  constructor (opts: {}, { stats }: MiddlewareServices) {
+    this.stats = stats
+  }
+
+  async applyToPipelines (pipelines: Pipelines, accountId: string) {
+    pipelines.incomingData.insertLast({
+      name: 'stats',
+      method: this.makeDataMiddleware('stats/incomingData/' + accountId)
+    })
+
+    pipelines.incomingMoney.insertLast({
+      name: 'stats',
+      method: async (amount: string, next: MiddlewareCallback<string, void>) => {
+        this.stats.counter('stats/incomingMoney/' + accountId, +amount)
+        return next(amount)
+      }
+    })
+
+    pipelines.outgoingData.insertLast({
+      name: 'stats',
+      method: this.makeDataMiddleware('stats/outgoingData/' + accountId)
+    })
+
+    pipelines.outgoingMoney.insertLast({
+      name: 'stats',
+      method: async (amount: string, next: MiddlewareCallback<string, void>) => {
+        this.stats.counter('stats/outgoingMoney/' + accountId, +amount)
+        return next(amount)
+      }
+    })
+  }
+
+  private makeDataMiddleware (prefix: string): MiddlewareMethod<Buffer,Buffer> {
+    return async (data: Buffer, next: MiddlewareCallback<Buffer, Buffer>) => {
+      if (data[0] !== IlpPacket.Type.TYPE_ILP_PREPARE) return next(data)
+      const { amount } = IlpPacket.deserializeIlpPrepare(data)
+      if (amount === '0') return next(data)
+      let result
+      try {
+        result = await next(data)
+      } catch (err) {
+        this.stats.counter(prefix + '/failed', +amount)
+        throw err
+      }
+      if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
+        this.stats.counter(prefix + '/fulfilled', +amount)
+      } else {
+        this.stats.counter(prefix + '/rejected', +amount)
+      }
+      return result
+    }
+  }
+}

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -209,4 +209,19 @@ export default class Accounts extends EventEmitter {
 
     return this.address + '.' + ilpAddressSegment
   }
+
+  getStatus () {
+    const accounts = {}
+    this.accounts.forEach((account, accountId) => {
+      accounts[accountId] = {
+        // Set info.options to undefined so that credentials aren't exposed.
+        info: Object.assign({}, account.info, { options: undefined }),
+        connected: account.plugin.isConnected()
+      }
+    })
+    return {
+      address: this.address,
+      accounts
+    }
+  }
 }

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -1,7 +1,12 @@
 import reduct = require('reduct')
+import { mapValues as pluck } from 'lodash'
+import Accounts from './accounts'
 import Config from './config'
+import MiddlewareManager from './middleware-manager'
 import RoutingTable from './routing-table'
 import RouteBroadcaster from './route-broadcaster'
+import Stats from './stats'
+import RateBackend from './rate-backend'
 import { formatRoutingTableAsJson } from '../routing/utils'
 import { Server, ServerRequest, ServerResponse } from 'http'
 
@@ -9,16 +14,24 @@ import { create as createLogger } from '../common/log'
 const log = createLogger('admin-api')
 
 export default class AdminApi {
+  private accounts: Accounts
   private config: Config
+  private middlewareManager: MiddlewareManager
   private routingTable: RoutingTable
   private routeBroadcaster: RouteBroadcaster
+  private rateBackend: RateBackend
+  private stats: Stats
 
   private server?: Server
 
   constructor (deps: reduct.Injector) {
+    this.accounts = deps(Accounts)
     this.config = deps(Config)
+    this.middlewareManager = deps(MiddlewareManager)
     this.routingTable = deps(RoutingTable)
     this.routeBroadcaster = deps(RouteBroadcaster)
+    this.rateBackend = deps(RateBackend)
+    this.stats = deps(Stats)
   }
 
   listen () {
@@ -34,54 +47,87 @@ export default class AdminApi {
       log.info('admin api listening. host=%s port=%s', adminApiHost, adminApiPort)
       this.server = new Server()
       this.server.listen(adminApiPort, adminApiHost)
-      this.server.on('request', this.handleRequest.bind(this))
+      this.server.on('request', (req, res) => {
+        this.handleRequest(req, res).catch((e) => {
+          let err = e
+          if (!e || typeof e !== 'object') {
+            err = new Error('non-object thrown. error=' + e)
+          }
+
+          log.warn('error in admin api request handler. error=%s', err.stack ? err.stack : err)
+          res.statusCode = 500
+          res.setHeader('Content-Type', 'text/plain')
+          res.end(String(err))
+        })
+      })
     }
   }
 
-  private handleRequest (req: ServerRequest, res: ServerResponse) {
+  private async handleRequest (req: ServerRequest, res: ServerResponse) {
     req.setEncoding('utf8')
-
     let body = ''
-    req.on('data', data => body += data)
-    req.on('end', () => {
-      try {
-        switch (req.url) {
-          case '/status':
-            res.statusCode = 200
-            res.setHeader('Content-Type', 'application/json')
-            res.end(JSON.stringify(this.getStatus()))
-            break
-          case '/routing':
-            res.statusCode = 200
-            res.setHeader('Content-Type', 'application/json')
-            res.end(JSON.stringify(this.getRoutingStatus()))
-            break
-          default:
-            res.statusCode = 404
-            res.setHeader('Content-Type', 'text/plain')
-            res.end('Not Found')
-        }
-      } catch (e) {
-        let err = e
-        if (!e || typeof e !== 'object') {
-          err = new Error('non-object thrown. error=' + e)
-        }
-
-        log.warn('error in admin api request handler. error=%s', err.stack ? err.stack : err)
-        res.statusCode = 500
-        res.setHeader('Content-Type', 'text/plain')
-        res.end(String(err))
-      }
+    await new Promise((resolve, reject) => {
+      req.on('data', data => body += data)
+      req.once('end', resolve)
+      req.once('error', reject)
     })
+
+    let status
+    switch (req.url) {
+      case '/status':
+        status = this.getStatus()
+        break
+      case '/routing':
+        status = this.getRoutingStatus()
+        break
+      case '/accounts':
+        status = this.getAccountStatus()
+        break
+      case '/balance':
+        status = this.getBalanceStatus()
+        break
+      case '/rates':
+        status = await this.getBackendStatus()
+        break
+      case '/stats':
+        status = this.getStats()
+        break
+      default:
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('Not Found')
+        return
+    }
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(status))
   }
 
   private getStatus () {
     return {
+      balances: pluck(this.getBalanceStatus()['accounts'], 'balance'),
+      connected: pluck(this.getAccountStatus()['accounts'], 'connected'),
       localRoutingTable: formatRoutingTableAsJson(this.routingTable)
     }
   }
 
   private getRoutingStatus () {
     return this.routeBroadcaster.getStatus()
+  }
+
+  private getAccountStatus () {
+    return this.accounts.getStatus()
+  }
+
+  private getBalanceStatus () {
+    return this.middlewareManager.getStatus('balance')
+  }
+
+  private getBackendStatus (): Promise<{ [s: string]: any }> {
+    return this.rateBackend.getStatus()
+  }
+
+  private getStats () {
+    return this.stats.getStatus()
   }
 }

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -1,0 +1,20 @@
+export default class Stats {
+  private counters: { [k: string]: number } = {}
+  private meters: { [k: string]: number } = {}
+
+  meter (key: string) {
+    this.meters[key] = (this.meters[key] || 0) + 1
+  }
+
+  counter (key: string, value: number) {
+    this.counters[key] = (this.counters[key] || 0) + value
+    this.meter(key)
+  }
+
+  getStatus () {
+    return {
+      counters: this.counters,
+      meters: this.meters
+    }
+  }
+}

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -5,10 +5,16 @@ export interface MiddlewareDefinition {
   options?: object
 }
 
+export interface MiddlewareStats {
+  meter (key: string)
+  counter (key: string, value: number)
+}
+
 /**
  * Services the connector exposes to middleware.
  */
 export interface MiddlewareServices {
+  stats: MiddlewareStats
   getInfo (accountId: string): AccountInfo
   getOwnAddress (): string
   sendData (data: Buffer, accountId: string): Promise<Buffer>
@@ -51,6 +57,7 @@ export interface Pipelines {
 
 export interface Middleware {
   applyToPipelines: (pipelines: Pipelines, accountId: string) => Promise<void>
+  getStatus?: () => { [s: string]: any }
 }
 
 export interface MiddlewareConstructor {

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -1,0 +1,288 @@
+'use strict'
+
+const chai = require('chai')
+const { assert } = chai
+const sinon = require('sinon')
+const { cloneDeep } = require('lodash')
+const IlpPacket = require('ilp-packet')
+const appHelper = require('./helpers/app')
+const logHelper = require('./helpers/log')
+const logger = require('../src/common/log')
+chai.use(require('chai-as-promised'))
+const { serializeCcpRouteUpdateRequest } = require('ilp-protocol-ccp')
+
+const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
+
+const mockPlugin = require('./mocks/mockPlugin')
+const mock = require('mock-require')
+mock('ilp-plugin-mock', mockPlugin)
+
+const env = cloneDeep(process.env)
+
+describe('AdminApi', function () {
+  logHelper(logger)
+  beforeEach(async function () {
+    this.accountData = Object.assign({}, require('./data/accountCredentials.json'))
+    Object.keys(this.accountData).forEach((accountId) => {
+      this.accountData[accountId] = Object.assign({
+        balance: {maximum: '1000'}
+      }, this.accountData[accountId])
+    })
+    process.env.CONNECTOR_ACCOUNTS = JSON.stringify(this.accountData)
+
+    appHelper.create(this)
+    this.clock = sinon.useFakeTimers(START_DATE)
+
+    await this.middlewareManager.setup()
+    await this.accounts.connect()
+    const testAccounts = ['test.cad-ledger', 'test.usd-ledger', 'test.eur-ledger', 'test.cny-ledger']
+    for (let accountId of testAccounts) {
+      this.routeBroadcaster.add(accountId)
+      this.accounts.getPlugin(accountId)._dataHandler(serializeCcpRouteUpdateRequest({
+        speaker: accountId,
+        routingTableId: 'b38e6e41-71a0-4088-baed-d2f09caa18ee',
+        currentEpochIndex: 1,
+        fromEpochIndex: 0,
+        toEpochIndex: 1,
+        holdDownTime: 45000,
+        withdrawnRoutes: [],
+        newRoutes: [{
+          prefix: accountId,
+          path: [accountId],
+          auth: Buffer.from('RLQ3sZWn8Y5TSNJM9qXszfxVlcuERxsxpy+7RhaUadk=', 'base64'),
+          props: []
+        }]
+      }))
+    }
+
+    await this.backend.connect()
+    await this.routeBroadcaster.reloadLocalRoutes()
+  })
+
+  beforeEach(async function () {
+    this.mockPlugin1 = this.accounts.getPlugin('test.usd-ledger')
+    this.mockPlugin2 = this.accounts.getPlugin('test.eur-ledger')
+
+    const preparePacket = IlpPacket.serializeIlpPrepare({
+      amount: '100',
+      executionCondition: Buffer.from('uzoYx3K6u+Nt6kZjbN6KmH0yARfhkj9e17eQfpSeB7U=', 'base64'),
+      expiresAt: new Date(START_DATE + 2000),
+      destination: 'test.eur-ledger.bob',
+      data: Buffer.alloc(0)
+    })
+    const fulfillPacket = IlpPacket.serializeIlpFulfill({
+      fulfillment: Buffer.from('HS8e5Ew02XKAglyus2dh2Ohabuqmy3HDM8EXMLz22ok', 'base64'),
+      data: Buffer.alloc(0)
+    })
+
+    sinon.stub(this.mockPlugin2, 'sendData').resolves(fulfillPacket)
+    const result = await this.mockPlugin1._dataHandler(preparePacket)
+    assert.equal(result.toString('hex'), fulfillPacket.toString('hex'))
+  })
+
+  afterEach(async function () {
+    this.clock.restore()
+    process.env = cloneDeep(env)
+  })
+
+  describe('getStatus', function () {
+    it('returns the status summary', function () {
+      assert.deepEqual(this.adminApi.getStatus(), {
+        balances: {
+          'test.cad-ledger': '0',
+          'test.usd-ledger': '100',
+          'test.eur-ledger': '-94',
+          'test.cny-ledger': '0'
+        },
+        connected: {
+          'test.cad-ledger': true,
+          'test.usd-ledger': true,
+          'test.eur-ledger': true,
+          'test.cny-ledger': true
+        },
+        localRoutingTable: {
+          'test.cad-ledger': {
+            auth: undefined,
+            nextHop: 'test.cad-ledger',
+            path: 'test.cad-ledger'
+          },
+          'test.cny-ledger': {
+            auth: undefined,
+            nextHop: 'test.cny-ledger',
+            path: 'test.cny-ledger'
+          },
+          'test.connie': {
+            auth: undefined,
+            nextHop: '',
+            path: ''
+          },
+          'test.eur-ledger': {
+            auth: undefined,
+            nextHop: 'test.eur-ledger',
+            path: 'test.eur-ledger'
+          },
+          'test.usd-ledger': {
+            auth: undefined,
+            nextHop: 'test.usd-ledger',
+            path: 'test.usd-ledger'
+          }
+        }
+      })
+    })
+  })
+
+  describe('getRoutingStatus', function () {
+    it('returns the routing status', function () {
+      const status = this.adminApi.getRoutingStatus()
+      assert.equal(typeof status.routingTableId, 'string')
+      assert.deepEqual(status, {
+        routingTableId: status.routingTableId, // this changes every time
+        currentEpoch: 5,
+        localRoutingTable: {
+          'test.connie': { nextHop: '', path: '', auth: undefined },
+          'test.cad-ledger': { nextHop: 'test.cad-ledger', path: 'test.cad-ledger', auth: undefined },
+          'test.usd-ledger': { nextHop: 'test.usd-ledger', path: 'test.usd-ledger', auth: undefined },
+          'test.eur-ledger': { nextHop: 'test.eur-ledger', path: 'test.eur-ledger', auth: undefined },
+          'test.cny-ledger': { nextHop: 'test.cny-ledger', path: 'test.cny-ledger', auth: undefined }
+        },
+        forwardingRoutingTable: {
+          'test.connie': { nextHop: '', path: 'test.connie', auth: undefined },
+          'test.cad-ledger': { nextHop: 'test.cad-ledger', path: 'test.connie test.cad-ledger', auth: undefined },
+          'test.usd-ledger': { nextHop: 'test.usd-ledger', path: 'test.connie test.usd-ledger', auth: undefined },
+          'test.eur-ledger': { nextHop: 'test.eur-ledger', path: 'test.connie test.eur-ledger', auth: undefined },
+          'test.cny-ledger': { nextHop: 'test.cny-ledger', path: 'test.connie test.cny-ledger', auth: undefined }
+        },
+        routingLog: [
+          {
+            prefix: 'test.connie',
+            route: { nextHop: '', path: 'test.connie', auth: undefined },
+            epoch: 0
+          },
+          {
+            prefix: 'test.cad-ledger',
+            route: { nextHop: 'test.cad-ledger', path: 'test.connie test.cad-ledger', auth: undefined },
+            epoch: 1
+          },
+          {
+            prefix: 'test.usd-ledger',
+            route: { nextHop: 'test.usd-ledger', path: 'test.connie test.usd-ledger', auth: undefined },
+            epoch: 2
+          },
+          {
+            prefix: 'test.eur-ledger',
+            route: { nextHop: 'test.eur-ledger', path: 'test.connie test.eur-ledger', auth: undefined },
+            epoch: 3
+          },
+          {
+            prefix: 'test.cny-ledger',
+            route: { nextHop: 'test.cny-ledger', path: 'test.connie test.cny-ledger', auth: undefined },
+            epoch: 4
+          }
+        ],
+        peers: {
+          'test.cad-ledger': {
+            send: { epoch: 0, mode: 'IDLE' },
+            receive: {
+              routingTableId: 'b38e6e41-71a0-4088-baed-d2f09caa18ee',
+              epoch: 1
+            }
+          },
+          'test.usd-ledger': {
+            send: { epoch: 0, mode: 'IDLE' },
+            receive: {
+              routingTableId: 'b38e6e41-71a0-4088-baed-d2f09caa18ee',
+              epoch: 1
+            }
+          },
+          'test.eur-ledger': {
+            send: { epoch: 0, mode: 'IDLE' },
+            receive: {
+              routingTableId: 'b38e6e41-71a0-4088-baed-d2f09caa18ee',
+              epoch: 1
+            }
+          },
+          'test.cny-ledger': {
+            send: { epoch: 0, mode: 'IDLE' },
+            receive: {
+              routingTableId: 'b38e6e41-71a0-4088-baed-d2f09caa18ee',
+              epoch: 1
+            }
+          }
+        }
+      })
+    })
+  })
+
+  describe('getAccountStatus', function () {
+    it('returns the account status', function () {
+      assert.deepEqual(this.adminApi.getAccountStatus(), {
+        address: 'test.connie',
+        accounts: {
+          'test.cad-ledger': {
+            info: Object.assign({}, this.accountData['test.cad-ledger'], { options: undefined }),
+            connected: true
+          },
+          'test.usd-ledger': {
+            info: Object.assign({}, this.accountData['test.usd-ledger'], { options: undefined }),
+            connected: true
+          },
+          'test.eur-ledger': {
+            info: Object.assign({}, this.accountData['test.eur-ledger'], { options: undefined }),
+            connected: true
+          },
+          'test.cny-ledger': {
+            info: Object.assign({}, this.accountData['test.cny-ledger'], { options: undefined }),
+            connected: true
+          }
+        }
+      })
+    })
+  })
+
+  describe('getBalanceStatus', function () {
+    it('returns the balance status', function () {
+      assert.deepEqual(this.adminApi.getBalanceStatus(), {
+        accounts: {
+          'test.cad-ledger': { balance: '0', minimum: '-Infinity', maximum: '1000' },
+          'test.usd-ledger': { balance: '100', minimum: '-Infinity', maximum: '1000' },
+          'test.eur-ledger': { balance: '-94', minimum: '-Infinity', maximum: '1000' },
+          'test.cny-ledger': { balance: '0', minimum: '-Infinity', maximum: '1000' }
+        }
+      })
+    })
+  })
+
+  describe('getBackendStatus', function () {
+    it('returns the rate backend status', async function () {
+      const rates = await this.adminApi.getBackendStatus()
+      const accounts = [
+        'test.cad-ledger',
+        'test.usd-ledger',
+        'test.eur-ledger',
+        'test.cny-ledger'
+      ]
+      assert.deepEqual(Object.keys(rates), accounts)
+      accounts.forEach((srcAccount) => {
+        accounts.forEach((dstAccount) => {
+          if (srcAccount === dstAccount) return
+          assert.equal(typeof rates[srcAccount][dstAccount], 'number')
+        })
+      })
+    })
+  })
+
+  describe('getStats', function () {
+    it('returns the collected stats', function () {
+      assert.deepEqual(this.adminApi.getStats(), {
+        counters: {
+          'stats/incomingData/test.usd-ledger/fulfilled': 100,
+          'stats/outgoingData/test.eur-ledger/fulfilled': 94
+        },
+        meters: {
+          'stats/incomingData/test.usd-ledger/fulfilled': 1,
+          'stats/outgoingData/test.eur-ledger/fulfilled': 1
+        }
+      })
+    })
+  })
+})

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -9,6 +9,7 @@ const Quoter = require('../../src/services/quoter').default
 const RateBackend = require('../../src/services/rate-backend').default
 const RoutingTable = require('../../src/services/routing-table').default
 const MiddlewareManager = require('../../src/services/middleware-manager').default
+const AdminApi = require('../../src/services/admin-api').default
 const CcpController = require('../../src/controllers/ccp').default
 const Store = require('../../src/services/store').default
 const ratesResponse = require('../data/fxRates.json')
@@ -46,6 +47,7 @@ exports.create = function (context, opts) {
   context.accounts = deps(Accounts)
   context.config = deps(Config)
   context.middlewareManager = deps(MiddlewareManager)
+  context.adminApi = deps(AdminApi)
   context.ccpController = deps(CcpController)
   context.store = deps(Store)
 }


### PR DESCRIPTION
Add endpoints to the admin API to expose info about accounts, balances, plugin throughput, and rates.

Minor fixes:

Fix README typo; enable eslint on tests (since they are in javascript, not typescript).