### PR TITLE
Performance: Cleanup redundant routes

### DIFF
--- a/src/routing/ccp-sender.ts
+++ b/src/routing/ccp-sender.ts
@@ -1,5 +1,5 @@
 import Accounts from '../services/accounts'
-import ForwardingRoutingTable from '../services/forwarding-routing-table'
+import ForwardingRoutingTable, { RouteUpdate } from '../services/forwarding-routing-table'
 import { BroadcastRoute } from '../types/routing'
 import { create as createLogger, ConnectorLogger } from '../common/log'
 import { Relation } from './relation'
@@ -189,8 +189,13 @@ export default class CcpSender {
       : nextRequestedEpoch
 
     const relation = this.getAccountRelation(this.accountId)
+    function isRouteUpdate (update: RouteUpdate | null): update is RouteUpdate {
+      return !!update
+    }
+
     const updates = allUpdates
-      .map(update => {
+      .filter(isRouteUpdate)
+      .map((update: RouteUpdate) => {
         if (!update.route) return update
 
         if (

--- a/src/routing/dragon.ts
+++ b/src/routing/dragon.ts
@@ -1,9 +1,8 @@
 import { Route } from '../types/routing'
-import PrefixMap from './prefix-map'
 import { create as createLogger } from '../common/log'
 const log = createLogger('dragon')
 import { Relation, getRelationPriority } from './relation'
-import ForwardingRoutingTable from '../services/forwarding-routing-table';
+import ForwardingRoutingTable from '../services/forwarding-routing-table'
 
 /**
  * Check whether a route can be filtered out based on DRAGON rules.

--- a/src/routing/utils.ts
+++ b/src/routing/utils.ts
@@ -1,4 +1,5 @@
 import { Route } from '../types/routing'
+import ForwardingRoutingTable, { RouteUpdate } from '../services/forwarding-routing-table'
 import PrefixMap from './prefix-map'
 import { mapValues } from 'lodash'
 
@@ -12,4 +13,12 @@ export function formatRouteAsJson (route: Route) {
 
 export function formatRoutingTableAsJson (routingTable: PrefixMap<Route>) {
   return mapValues(routingTable.toJSON(), formatRouteAsJson)
+}
+
+export function formatForwardingRoutingTableAsJson (routingTable: ForwardingRoutingTable) {
+  return mapValues(routingTable.toJSON(), (routeUpdate: RouteUpdate) => (
+    routeUpdate.route
+    ? formatRouteAsJson(routeUpdate.route)
+    : null
+  ))
 }

--- a/src/services/forwarding-routing-table.ts
+++ b/src/services/forwarding-routing-table.ts
@@ -8,8 +8,8 @@ export interface RouteUpdate {
   route?: Route
 }
 
-export default class ForwardingRoutingTable extends PrefixMap<Route> {
+export default class ForwardingRoutingTable extends PrefixMap<RouteUpdate> {
   public routingTableId: string = uuid()
-  public log: RouteUpdate[] = []
+  public log: (RouteUpdate | null)[] = []
   public currentEpoch: number = 0
 }

--- a/src/services/route-broadcaster.ts
+++ b/src/services/route-broadcaster.ts
@@ -495,11 +495,7 @@ export default class RouteBroadcaster {
         epoch
       }
 
-      if (route) {
-        this.forwardingRoutingTable.insert(prefix, routeUpdate)
-      } else {
-        this.forwardingRoutingTable.insert(prefix, routeUpdate)
-      }
+      this.forwardingRoutingTable.insert(prefix, routeUpdate)
 
       log.debug('logging route update. update=%j', routeUpdate)
 

--- a/test/route-broadcaster.test.js
+++ b/test/route-broadcaster.test.js
@@ -282,7 +282,6 @@ describe('RouteBroadcaster', function () {
         ],
         newRoutes: routesWithSourceLedgerB.filter(r => r.prefix !== 'test.cad-ledger')
       }) || true))
-      throw new Error()
     })
 
     it('invalidates routes', async function () {


### PR DESCRIPTION
Previously, connectors would broadcast a full history of their routing table changes:

```
1: g.u1 => g.u1
2: g.u2 => g.u1 g.u2
3: g.u2 withdrawn
```

However, if an update is overwritten by a later update, we can safely delete it. E.g. this log is equivalent:

```
1: g.u1 => g.u1
3: g.u2 withdrawn
```

Note that we can't delete update no.3 even though it is now a no-op for anyone downloading the table from scratch. This is because someone might have downloaded our routing table up to epoch 2 and they still need to know that we no longer serve this route.

Both route changes and route withdrawals can be removed from the log when a new entry for the same entry is added, regardless of whether the new entry is adding, changing, or removing the route. When adding a route update to the log, there will be at most one previous update for that prefix in the log. We may safely delete it.