### PR TITLE
feat: use Prometheus-compatible metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 *.log
 /.tags*
 /web/
+.vscode/settings.json

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "long": "^4.0.0",
     "node-fetch": "^2.0.0",
     "oer-utils": "^1.3.4",
+    "prom-client": "^11.1.1",
     "reduct": "^3.2.0",
     "riverpig": "^1.1.3",
     "sax": "^1.2.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import RateBackend from './services/rate-backend'
 import Store from './services/store'
 import MiddlewareManager from './services/middleware-manager'
 import AdminApi from './services/admin-api'
-
+import * as Prometheus from 'prom-client'
 import { PluginInstance } from './types/plugin'
 
 function listen (
@@ -57,6 +57,10 @@ function listen (
     })
 
     await middlewareManager.startup()
+
+    if (config.collectDefaultMetrics) {
+      Prometheus.collectDefaultMetrics()
+    }
 
     adminApi.listen()
 

--- a/src/middlewares/balance.ts
+++ b/src/middlewares/balance.ts
@@ -180,13 +180,13 @@ export default class BalanceMiddleware implements Middleware {
             try {
               result = await next(data)
             } catch (err) {
-              log.debug('outgoing packet refunded due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              log.debug('outgoing packet not applied due to error. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
               this.stats.outgoingDataPacketValue.increment(account, { result : 'failed' }, +parsedPacket.amount)
               throw err
             }
 
             if (result[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
-              log.debug('outgoing packet refunded due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              log.debug('outgoing packet not applied due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
               this.stats.outgoingDataPacketValue.increment(account, { result : 'rejected' }, +parsedPacket.amount)
             } else if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
               // Decrease balance on prepare

--- a/src/middlewares/balance.ts
+++ b/src/middlewares/balance.ts
@@ -142,7 +142,7 @@ export default class BalanceMiddleware implements Middleware {
               this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
               this.stats.incomingDataPacketValue.increment(account, { result : 'rejected' }, +parsedPacket.amount)
             } else if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
-              this.maybeSettle(accountId)
+              this.maybeSettle(accountId).catch(log.error)
               this.stats.incomingDataPacketValue.increment(account, { result : 'fulfilled' }, +parsedPacket.amount)
             }
 
@@ -197,7 +197,7 @@ export default class BalanceMiddleware implements Middleware {
               this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
               this.stats.outgoingDataPacketValue.increment(account, { result : 'rejected' }, +parsedPacket.amount)
             } else if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
-              this.maybeSettle(accountId)
+              this.maybeSettle(accountId).catch(log.error)
               this.stats.outgoingDataPacketValue.increment(account, { result : 'fulfilled' }, +parsedPacket.amount)
             }
 
@@ -244,7 +244,7 @@ export default class BalanceMiddleware implements Middleware {
       balance.add(amountDiff)
     } else {
       balance.subtract(amountDiff.negated())
-      this.maybeSettle(accountId)
+      this.maybeSettle(accountId).catch(log.error)
     }
     this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
     return balance.getValue()

--- a/src/middlewares/balance.ts
+++ b/src/middlewares/balance.ts
@@ -4,6 +4,8 @@ import { Middleware, MiddlewareCallback, MiddlewareServices, Pipelines } from '.
 import { AccountInfo } from '../types/accounts'
 import BigNumber from 'bignumber.js'
 import * as IlpPacket from 'ilp-packet'
+import Stats from '../services/stats'
+
 const { InsufficientLiquidityError } = IlpPacket.Errors
 
 interface BalanceOpts {
@@ -16,7 +18,6 @@ class Balance {
   private balance: BigNumber
   private minimum: BigNumber
   private maximum: BigNumber
-
   constructor ({
     initialBalance = new BigNumber(0),
     minimum = new BigNumber(0),
@@ -63,13 +64,15 @@ class Balance {
 }
 
 export default class BalanceMiddleware implements Middleware {
+  private stats: Stats
   private getInfo: (accountId: string) => AccountInfo
   private sendMoney: (amount: string, accountId: string) => Promise<void>
   private balances: Map<string, Balance> = new Map()
 
-  constructor (opts: {}, { getInfo, sendMoney }: MiddlewareServices) {
+  constructor (opts: {}, { getInfo, sendMoney, stats }: MiddlewareServices) {
     this.getInfo = getInfo
     this.sendMoney = sendMoney
+    this.stats = stats
   }
 
   async applyToPipelines (pipelines: Pipelines, accountId: string) {
@@ -77,14 +80,14 @@ export default class BalanceMiddleware implements Middleware {
     if (!accountInfo) {
       throw new Error('could not load info for account. accountId=' + accountId)
     }
-
+    const account = { accountId, accountInfo }
     if (accountInfo.balance) {
       const {
         minimum = '-Infinity',
         maximum
       } = accountInfo.balance
 
-      let balance = new Balance({
+      const balance = new Balance({
         minimum: new BigNumber(minimum),
         maximum: new BigNumber(maximum)
       })
@@ -99,6 +102,7 @@ export default class BalanceMiddleware implements Middleware {
           // tslint:disable-next-line:no-floating-promises
           this.maybeSettle(accountId)
 
+          this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
           return next(dummy)
         }
       })
@@ -117,6 +121,7 @@ export default class BalanceMiddleware implements Middleware {
             // Increase balance on prepare
             balance.add(parsedPacket.amount)
             log.debug('balance increased due to incoming ilp prepare. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+            this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
 
             let result
             try {
@@ -125,6 +130,8 @@ export default class BalanceMiddleware implements Middleware {
               // Refund on error
               balance.subtract(parsedPacket.amount)
               log.debug('incoming packet refunded due to error. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
+              this.stats.incomingDataPacketValue.increment(account, { result : 'failed' }, +parsedPacket.amount)
               throw err
             }
 
@@ -132,6 +139,11 @@ export default class BalanceMiddleware implements Middleware {
               // Refund on reject
               balance.subtract(parsedPacket.amount)
               log.debug('incoming packet refunded due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
+              this.stats.incomingDataPacketValue.increment(account, { result : 'rejected' }, +parsedPacket.amount)
+            } else if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
+              this.maybeSettle(accountId)
+              this.stats.incomingDataPacketValue.increment(account, { result : 'fulfilled' }, +parsedPacket.amount)
             }
 
             return result
@@ -146,7 +158,7 @@ export default class BalanceMiddleware implements Middleware {
         method: async (amount: string, next: MiddlewareCallback<string, void>) => {
           balance.subtract(amount)
           log.debug('balance reduced due to incoming settlement. accountId=%s amount=%s newBalance=%s', accountId, amount, balance.getValue())
-
+          this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
           return next(amount)
         }
       })
@@ -162,25 +174,31 @@ export default class BalanceMiddleware implements Middleware {
               return next(data)
             }
 
+            balance.subtract(parsedPacket.amount)
+            log.debug('balance decreased due to outgoing ilp prepare. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+            this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
+
             let result
             try {
               result = await next(data)
             } catch (err) {
-              // Do not apply any changes on an error
-              log.debug('outgoing packet not applied due to error. accountId=%s amount=%s balance=%s', accountId, parsedPacket.amount, balance.getValue())
+              // Reverse changes on an error
+              balance.add(parsedPacket.amount)
+              log.debug('outgoing packet refunded due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
+              this.stats.outgoingDataPacketValue.increment(account, { result : 'failed' }, +parsedPacket.amount)
               throw err
             }
 
             if (result[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
-              // Do not apply any changes on reject
-              log.debug('outgoing packet not applied due to ilp reject. accountId=%s amount=%s balance=%s', accountId, parsedPacket.amount, balance.getValue())
+              // Reverse changes on reject
+              balance.add(parsedPacket.amount)
+              log.debug('outgoing packet refunded due to ilp reject. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
+              this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
+              this.stats.outgoingDataPacketValue.increment(account, { result : 'rejected' }, +parsedPacket.amount)
             } else if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
-              // Decrease balance on prepare
-              balance.subtract(parsedPacket.amount)
-              log.debug('balance decreased due to outgoing ilp packet being fulfilled. accountId=%s amount=%s newBalance=%s', accountId, parsedPacket.amount, balance.getValue())
-
-              // tslint:disable-next-line:no-floating-promises
               this.maybeSettle(accountId)
+              this.stats.outgoingDataPacketValue.increment(account, { result : 'fulfilled' }, +parsedPacket.amount)
             }
 
             return result
@@ -195,6 +213,7 @@ export default class BalanceMiddleware implements Middleware {
         method: async (amount: string, next: MiddlewareCallback<string, void>) => {
           balance.add(amount)
           log.debug('balance increased due to outgoing settlement. accountId=%s amount=%s newBalance=%s', accountId, amount, balance.getValue())
+          this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
 
           return next(amount)
         }
@@ -213,6 +232,11 @@ export default class BalanceMiddleware implements Middleware {
   }
 
   modifyBalance (accountId: string, _amountDiff: BigNumber.Value): BigNumber {
+    const accountInfo = this.getInfo(accountId)
+    if (!accountInfo) {
+      throw new Error('could not load info for account. accountId=' + accountId)
+    }
+    const account = { accountId, accountInfo }
     const amountDiff = new BigNumber(_amountDiff)
     const balance = this.getBalance(accountId)
     log.warn('modifying balance accountId=%s amount=%s', accountId, amountDiff.toString())
@@ -220,9 +244,9 @@ export default class BalanceMiddleware implements Middleware {
       balance.add(amountDiff)
     } else {
       balance.subtract(amountDiff.negated())
-      // tslint:disable-next-line:no-floating-promises
       this.maybeSettle(accountId)
     }
+    this.stats.balance.setValue(account, {}, balance.getValue().toNumber())
     return balance.getValue()
   }
 

--- a/src/middlewares/stats.ts
+++ b/src/middlewares/stats.ts
@@ -2,14 +2,11 @@ import * as IlpPacket from 'ilp-packet'
 import {
   Middleware,
   MiddlewareCallback,
-  MiddlewareMethod,
   MiddlewareServices,
   Pipelines
 } from '../types/middleware'
 import Stats from '../services/stats'
 import { AccountInfo } from '../types/accounts'
-import { create as createLogger } from '../common/log'
-const log = createLogger('stats-middleware')
 
 export default class StatsMiddleware implements Middleware {
   private stats: Stats

--- a/src/middlewares/stats.ts
+++ b/src/middlewares/stats.ts
@@ -4,63 +4,94 @@ import {
   MiddlewareCallback,
   MiddlewareMethod,
   MiddlewareServices,
-  MiddlewareStats,
   Pipelines
 } from '../types/middleware'
+import Stats from '../services/stats'
+import { AccountInfo } from '../types/accounts'
+import { create as createLogger } from '../common/log'
+const log = createLogger('stats-middleware')
 
 export default class StatsMiddleware implements Middleware {
-  private stats: MiddlewareStats
+  private stats: Stats
 
-  constructor (opts: {}, { stats }: MiddlewareServices) {
+  private getInfo: (accountId: string) => AccountInfo
+
+  constructor (opts: {}, { stats, getInfo }: MiddlewareServices) {
     this.stats = stats
+    this.getInfo = getInfo
   }
 
   async applyToPipelines (pipelines: Pipelines, accountId: string) {
+    const accountInfo = this.getInfo(accountId)
+    if (!accountInfo) {
+      throw new Error('could not load info for account. accountId=' + accountId)
+    }
+    const account = { accountId, accountInfo }
     pipelines.incomingData.insertLast({
       name: 'stats',
-      method: this.makeDataMiddleware('stats/incomingData/' + accountId)
+      method: async (data: Buffer, next: MiddlewareCallback<Buffer, Buffer>) => {
+        try {
+          const result = await next(data)
+          if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
+            this.stats.incomingDataPackets.increment(account, { result: 'fulfilled' })
+          } else {
+            this.stats.incomingDataPackets.increment(account, { result: 'rejected' })
+          }
+          return result
+        } catch (err) {
+          this.stats.incomingDataPackets.increment(account, { result: 'failed' })
+          throw err
+        }
+      }
     })
 
     pipelines.incomingMoney.insertLast({
       name: 'stats',
       method: async (amount: string, next: MiddlewareCallback<string, void>) => {
-        this.stats.counter('stats/incomingMoney/' + accountId, +amount)
-        return next(amount)
+        try {
+          const result = await next(amount)
+          this.stats.incomingMoney.setValue(account, { result: 'succeeded' }, +amount)
+          return result
+        } catch (err) {
+          this.stats.incomingMoney.setValue(account, { result: 'failed' }, +amount)
+          throw err
+        }
       }
     })
 
     pipelines.outgoingData.insertLast({
       name: 'stats',
-      method: this.makeDataMiddleware('stats/outgoingData/' + accountId)
+      method: async (data: Buffer, next: MiddlewareCallback<Buffer, Buffer>) => {
+        try {
+          const result = await next(data)
+          if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
+            this.stats.outgoingDataPackets.increment(account, { result: 'fulfilled' })
+          } else {
+            const rejectPacket = IlpPacket.deserializeIlpReject(result)
+            const { code, triggeredBy } = rejectPacket
+            this.stats.outgoingDataPackets.increment(account,
+              { result: 'rejected', code, triggeredBy })
+          }
+          return result
+        } catch (err) {
+          this.stats.outgoingDataPackets.increment(account, { result: 'failed' })
+          throw err
+        }
+      }
     })
 
     pipelines.outgoingMoney.insertLast({
       name: 'stats',
       method: async (amount: string, next: MiddlewareCallback<string, void>) => {
-        this.stats.counter('stats/outgoingMoney/' + accountId, +amount)
-        return next(amount)
+        try {
+          const result = await next(amount)
+          this.stats.outgoingMoney.setValue(account, { result: 'succeeded' }, +amount)
+          return result
+        } catch (err) {
+          this.stats.outgoingMoney.setValue(account, { result: 'failed' }, +amount)
+          throw err
+        }
       }
     })
-  }
-
-  private makeDataMiddleware (prefix: string): MiddlewareMethod<Buffer,Buffer> {
-    return async (data: Buffer, next: MiddlewareCallback<Buffer, Buffer>) => {
-      if (data[0] !== IlpPacket.Type.TYPE_ILP_PREPARE) return next(data)
-      const { amount } = IlpPacket.deserializeIlpPrepare(data)
-      if (amount === '0') return next(data)
-      let result
-      try {
-        result = await next(data)
-      } catch (err) {
-        this.stats.counter(prefix + '/failed', +amount)
-        throw err
-      }
-      if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
-        this.stats.counter(prefix + '/fulfilled', +amount)
-      } else {
-        this.stats.counter(prefix + '/rejected', +amount)
-      }
-      return result
-    }
   }
 }

--- a/src/schemas/Config.json
+++ b/src/schemas/Config.json
@@ -317,6 +317,11 @@
       "description": "Host to bind to. Warning: The admin API interface should never be made public! Default: '127.0.0.1'",
       "type": "string",
       "default": "127.0.0.1"
+    },
+    "collectDefaultMetrics": {
+      "description": "Whether the Prometheus exporter should include system metrics or not. Default: false (no)",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["accounts"],

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -14,8 +14,8 @@ import { formatRoutingTableAsJson } from '../routing/utils'
 import { Server, ServerRequest, ServerResponse } from 'http'
 import InvalidJsonBodyError from '../errors/invalid-json-body-error'
 import { BalanceUpdate } from '../schemas/BalanceUpdate'
-
 import { create as createLogger } from '../common/log'
+import * as Prometheus from 'prom-client'
 const log = createLogger('admin-api')
 const ajv = new Ajv()
 const validateBalanceUpdate = ajv.compile(require('../schemas/BalanceUpdate.json'))
@@ -23,7 +23,8 @@ const validateBalanceUpdate = ajv.compile(require('../schemas/BalanceUpdate.json
 interface Route {
   method: 'GET' | 'POST' | 'DELETE'
   match: string
-  fn: (url: string, body: object) => Promise<object | void>
+  fn: (url: string, body: Object) => Promise<Object | string | void>
+  responseType?: string
 }
 
 export default class AdminApi {
@@ -56,7 +57,8 @@ export default class AdminApi {
       { method: 'GET', match: '/rates$', fn: this.getBackendStatus },
       { method: 'GET', match: '/stats$', fn: this.getStats },
       { method: 'GET', match: '/alerts$', fn: this.getAlerts },
-      { method: 'DELETE', match: '/alerts/', fn: this.deleteAlert }
+      { method: 'DELETE', match: '/alerts/', fn: this.deleteAlert },
+      { method: 'GET', match: '/metrics$', fn: this.getMetrics, responseType: Prometheus.register.contentType }
     ]
   }
 
@@ -111,8 +113,13 @@ export default class AdminApi {
     const resBody = await route.fn.call(this, req.url, body && JSON.parse(body))
     if (resBody) {
       res.statusCode = 200
-      res.setHeader('Content-Type', 'application/json')
-      res.end(JSON.stringify(resBody))
+      if (route.responseType) {
+        res.setHeader('Content-Type', route.responseType)
+        res.end(resBody)
+      } else {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(resBody))
+      }
     } else {
       res.statusCode = 204
       res.end()
@@ -144,7 +151,7 @@ export default class AdminApi {
     return balanceMiddleware.getStatus()
   }
 
-  private async postBalance (url: string, _data: object) {
+  private async postBalance (url: string, _data: Object) {
     try {
       validateBalanceUpdate(_data)
     } catch (err) {
@@ -178,7 +185,7 @@ export default class AdminApi {
     }
   }
 
-  private async deleteAlert (url: string, _: object) {
+  private async deleteAlert (url: string) {
     const middleware = this.middlewareManager.getMiddleware('alert')
     if (!middleware) return {}
     const alertMiddleware = middleware as AlertMiddleware
@@ -186,4 +193,9 @@ export default class AdminApi {
     if (!match) throw new Error('invalid alert id')
     alertMiddleware.dismissAlert(+match[1])
   }
+
+  private async getMetrics () {
+    return Prometheus.register.metrics()
+  }
+
 }

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -151,7 +151,7 @@ export default class AdminApi {
     return balanceMiddleware.getStatus()
   }
 
-  private async postBalance (url: string, _data: Object) {
+  private async postBalance (url: string, _data: object) {
     try {
       validateBalanceUpdate(_data)
     } catch (err) {

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -23,7 +23,7 @@ const validateBalanceUpdate = ajv.compile(require('../schemas/BalanceUpdate.json
 interface Route {
   method: 'GET' | 'POST' | 'DELETE'
   match: string
-  fn: (url: string, body: Object) => Promise<Object | string | void>
+  fn: (url: string, body: object) => Promise<object | string | void>
   responseType?: string
 }
 

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -1,20 +1,84 @@
+import * as Prometheus from 'prom-client'
+import { AccountInfo } from '../types/accounts'
+
+function mergeAccountLabels (account: { accountId: string, accountInfo: AccountInfo }, labels: Prometheus.labelValues): Prometheus.labelValues {
+  labels['account'] = account.accountId
+  labels['asset'] = account.accountInfo.assetCode
+  labels['scale'] = account.accountInfo.assetScale
+  return labels
+}
+
+export class AccountCounter extends Prometheus.Counter {
+  constructor (configuration: Prometheus.CounterConfiguration) {
+    configuration.labelNames = (configuration.labelNames || [])
+    configuration.labelNames.push('account', 'asset', 'scale')
+    super(configuration)
+  }
+  increment (account: { accountId: string, accountInfo: AccountInfo }, labels: Prometheus.labelValues, value?: number) {
+    return this.inc(mergeAccountLabels(account, labels), value)
+  }
+}
+
+export class AccountGuage extends Prometheus.Gauge {
+  constructor (configuration: Prometheus.GaugeConfiguration) {
+    configuration.labelNames = (configuration.labelNames || [])
+    configuration.labelNames.push('account', 'asset', 'scale')
+    super(configuration)
+  }
+  setValue (account: { accountId: string, accountInfo: AccountInfo }, labels: Prometheus.labelValues, value: number) {
+    return this.set(mergeAccountLabels(account, labels), value)
+  }
+}
+
 export default class Stats {
-  private counters: { [k: string]: number } = {}
-  private meters: { [k: string]: number } = {}
+  public incomingDataPackets = new AccountCounter({
+    name: 'ilp_connector_incoming_ilp_packets',
+    help: 'Total number of incoming ILP packets',
+    labelNames: [ 'result', 'code' , 'triggeredBy'] })
 
-  meter (key: string) {
-    this.meters[key] = (this.meters[key] || 0) + 1
-  }
+  public incomingDataPacketValue = new AccountCounter({
+    name: 'ilp_connector_incoming_ilp_packet_value',
+    help: 'Total value of incoming ILP packets',
+    labelNames: [ 'result', 'code' , 'triggeredBy'] })
 
-  counter (key: string, value: number) {
-    this.counters[key] = (this.counters[key] || 0) + value
-    this.meter(key)
-  }
+  public outgoingDataPackets = new AccountCounter({
+    name: 'ilp_connector_outgoing_ilp_packets',
+    help: 'Total number of outgoing ILP packets',
+    labelNames: [ 'result', 'code', 'triggeredBy' ] })
+
+  public outgoingDataPacketValue = new AccountCounter({
+    name: 'ilp_connector_outgoing_ilp_packet_value',
+    help: 'Total value of outgoing ILP packets',
+    labelNames: [ 'result', 'code', 'triggeredBy' ] })
+
+  public incomingMoney = new AccountGuage({
+    name: 'ilp_connector_incoming_money',
+    help: 'Total of incoming money',
+    labelNames: [ 'result' ] })
+
+  public outgoingMoney = new AccountGuage({
+    name: 'ilp_connector_outgoing_money',
+    help: 'Total of outgoing money',
+    labelNames: [ 'result' ] })
+
+  public rateLimitedPackets = new AccountCounter({
+    name: 'ilp_connector_rate_limited_ilp_packets',
+    help: 'Total of rate limited ILP packets' })
+
+  public rateLimitedMoney = new AccountCounter({
+    name: 'ilp_connector_rate_limited_money',
+    help: 'Total of rate limited money requests' })
+
+  public balance = new AccountGuage({
+    name: 'ilp_connector_balance',
+    help: 'Balances on peer account' })
 
   getStatus () {
-    return {
-      counters: this.counters,
-      meters: this.meters
-    }
+    return Prometheus.register.getMetricsAsJSON()
   }
+
+  collectDefaultMetrics () {
+    Prometheus.collectDefaultMetrics()
+  }
+
 }

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -76,9 +76,4 @@ export default class Stats {
   getStatus () {
     return Prometheus.register.getMetricsAsJSON()
   }
-
-  collectDefaultMetrics () {
-    Prometheus.collectDefaultMetrics()
-  }
-
 }

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,20 +1,16 @@
 import { AccountInfo } from './accounts'
+import Stats from '../services/stats'
 
 export interface MiddlewareDefinition {
   type: string,
   options?: object
 }
 
-export interface MiddlewareStats {
-  meter (key: string)
-  counter (key: string, value: number)
-}
-
 /**
  * Services the connector exposes to middleware.
  */
 export interface MiddlewareServices {
-  stats: MiddlewareStats
+  stats: Stats
   getInfo (accountId: string): AccountInfo
   getOwnAddress (): string
   sendData (data: Buffer, accountId: string): Promise<Buffer>

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -272,16 +272,154 @@ describe('AdminApi', function () {
 
   describe('getStats', function () {
     it('returns the collected stats', async function () {
-      assert.deepEqual(await this.adminApi.getStats(), {
-        counters: {
-          'stats/incomingData/test.usd-ledger/fulfilled': 100,
-          'stats/outgoingData/test.eur-ledger/fulfilled': 94
+      const metrics = await this.adminApi.getStats()
+      const expected = [{
+        help: 'Total number of incoming ILP packets',
+        name: 'ilp_connector_incoming_ilp_packets',
+        type: 'counter',
+        values: [{
+          value: 1,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.cad-ledger',
+            asset: 'CAD',
+            scale: 4
+          },
+          timestamp: undefined
         },
-        meters: {
-          'stats/incomingData/test.usd-ledger/fulfilled': 1,
-          'stats/outgoingData/test.eur-ledger/fulfilled': 1
-        }
-      })
+        {
+          value: 2,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.usd-ledger',
+            asset: 'USD',
+            scale: 4
+          },
+          timestamp: undefined
+        },
+        {
+          value: 1,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.eur-ledger',
+            asset: 'EUR',
+            scale: 4
+          },
+          timestamp: undefined
+        },
+        {
+          value: 1,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.cny-ledger',
+            asset: 'CNY',
+            scale: 4
+          },
+          timestamp: undefined
+        }],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total value of incoming ILP packets',
+        name: 'ilp_connector_incoming_ilp_packet_value',
+        type: 'counter',
+        values: [{
+          value: 100,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.usd-ledger',
+            asset: 'USD',
+            scale: 4
+          },
+          timestamp: undefined
+        }],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total number of outgoing ILP packets',
+        name: 'ilp_connector_outgoing_ilp_packets',
+        type: 'counter',
+        values: [{
+          value: 1,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.eur-ledger',
+            asset: 'EUR',
+            scale: 4
+          },
+          timestamp: undefined
+        }],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total value of outgoing ILP packets',
+        name: 'ilp_connector_outgoing_ilp_packet_value',
+        type: 'counter',
+        values: [{
+          value: 94,
+          labels:
+          {
+            result: 'fulfilled',
+            account: 'test.eur-ledger',
+            asset: 'EUR',
+            scale: 4
+          },
+          timestamp: undefined
+        }],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total of incoming money',
+        name: 'ilp_connector_incoming_money',
+        type: 'gauge',
+        values: [],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total of outgoing money',
+        name: 'ilp_connector_outgoing_money',
+        type: 'gauge',
+        values: [],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total of rate limited ILP packets',
+        name: 'ilp_connector_rate_limited_ilp_packets',
+        type: 'counter',
+        values: [],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Total of rate limited money requests',
+        name: 'ilp_connector_rate_limited_money',
+        type: 'counter',
+        values: [],
+        aggregator: 'sum'
+      },
+      {
+        help: 'Balances on peer account',
+        name: 'ilp_connector_balance',
+        type: 'gauge',
+        values: [{
+          value: 100,
+          labels: { account: 'test.usd-ledger', asset: 'USD', scale: 4 },
+          timestamp: undefined
+        },
+        {
+          value: -94,
+          labels: { account: 'test.eur-ledger', asset: 'EUR', scale: 4 },
+          timestamp: undefined
+        }],
+        aggregator: 'sum'
+      }]
+
+      assert.deepEqual(metrics, expected)
     })
   })
 

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const reduct = require('reduct')
+const Prometheus = require('prom-client')
 const Config = require('../../src/services/config').default
 const RouteBuilder = require('../../src/services/route-builder').default
 const RouteBroadcaster = require('../../src/services/route-broadcaster').default
@@ -34,6 +35,8 @@ exports.create = function (context, opts) {
       mockData: ratesResponse
     })
   }
+
+  Prometheus.register.clear() // Clear metrics
 
   const deps = reduct()
   const app = createApp(opts || null, deps)


### PR DESCRIPTION
BREAKING: Admin API `/stats` endpoint uses new format

This change modifies the admin API as follows:

1. The `/stats` endpoint is a new more verbose format to better reflect the new data model for metrics.
2. There is a new `/metrics` endpoint for consumption by a Prometheus scraper job allowing the data to be recorded as time series and properly analyzed.