### PR TITLE
Feat: add admin info interface to accounts

### DIFF
--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -216,7 +216,8 @@ export default class Accounts extends EventEmitter {
       accounts[accountId] = {
         // Set info.options to undefined so that credentials aren't exposed.
         info: Object.assign({}, account.info, { options: undefined }),
-        connected: account.plugin.isConnected()
+        connected: account.plugin.isConnected(),
+        adminInfo: !!account.plugin.getAdminInfo
       }
     })
     return {

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -52,6 +52,8 @@ export default class AdminApi {
       { method: 'GET', match: '/status$', fn: this.getStatus },
       { method: 'GET', match: '/routing$', fn: this.getRoutingStatus },
       { method: 'GET', match: '/accounts$', fn: this.getAccountStatus },
+      { method: 'GET', match: '/accounts/', fn: this.getAccountAdminInfo },
+      { method: 'POST', match: '/accounts/', fn: this.sendAccountAdminInfo },
       { method: 'GET', match: '/balance$', fn: this.getBalanceStatus },
       { method: 'POST', match: '/balance$', fn: this.postBalance },
       { method: 'GET', match: '/rates$', fn: this.getBackendStatus },
@@ -198,4 +200,38 @@ export default class AdminApi {
     return Prometheus.register.metrics()
   }
 
+  private _getPlugin (url: string) {
+    const match = /^\/accounts\/([A-Za-z0-9_.\-~]+)$/.exec(url.split('?')[0])
+    if (!match) throw new Error('invalid account.')
+    const account = match[1]
+    const plugin = this.accounts.getPlugin(account)
+    if (!plugin) throw new Error('account does not exist. account=' + account)
+    const info = this.accounts.getInfo(account)
+    return {
+      account,
+      info,
+      plugin
+    }
+  }
+
+  private async getAccountAdminInfo (url: string) {
+    const { account, info, plugin } = this._getPlugin(url)
+    if (!plugin.getAdminInfo) throw new Error('plugin has no admin info. account=' + account)
+    return {
+      account,
+      plugin: info.plugin,
+      info: (await plugin.getAdminInfo())
+    }
+  }
+
+  private async sendAccountAdminInfo (url: string, body?: object) {
+    if (!body) throw new Error('no json body provided to set admin info.')
+    const { account, info, plugin } = this._getPlugin(url)
+    if (!plugin.sendAdminInfo) throw new Error('plugin does not support sending admin info. account=' + account)
+    return {
+      account,
+      plugin: info.plugin,
+      result: (await plugin.sendAdminInfo(body))
+    }
+  }
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -22,4 +22,6 @@ export interface PluginInstance extends EventEmitter {
   deregisterDataHandler (): void
   registerMoneyHandler (moneyHandler: MoneyHandler): void
   deregisterMoneyHandler (): void
+  getAdminInfo? (): Promise<object>
+  sendAdminInfo? (info: object): Promise<object>
 }

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -219,19 +219,23 @@ describe('AdminApi', function () {
         accounts: {
           'test.cad-ledger': {
             info: Object.assign({}, this.accountData['test.cad-ledger'], { options: undefined }),
-            connected: true
+            connected: true,
+            adminInfo: true
           },
           'test.usd-ledger': {
             info: Object.assign({}, this.accountData['test.usd-ledger'], { options: undefined }),
-            connected: true
+            connected: true,
+            adminInfo: true
           },
           'test.eur-ledger': {
             info: Object.assign({}, this.accountData['test.eur-ledger'], { options: undefined }),
-            connected: true
+            connected: true,
+            adminInfo: true
           },
           'test.cny-ledger': {
             info: Object.assign({}, this.accountData['test.cny-ledger'], { options: undefined }),
-            connected: true
+            connected: true,
+            adminInfo: true
           }
         }
       })
@@ -498,6 +502,36 @@ describe('AdminApi', function () {
 
     it('deletes an alert', async function () {
       await this.adminApi.deleteAlert('/alerts/' + this.alertId, null)
+    })
+  })
+
+  describe('plugin admin api', function () {
+    describe('getAccountAdminInfo', function () {
+      it('returns result of getAdminInfo', async function () {
+        const res = await this.adminApi.getAccountAdminInfo('/accounts/test.usd-ledger')
+        assert.deepEqual(res, {
+          account: 'test.usd-ledger',
+          plugin: 'ilp-plugin-mock',
+          info: {
+            foo: 'bar'
+          }
+        })
+      })
+    })
+
+    describe('sendAccountAdminInfo', function () {
+      it('passes the object into sendAdminInfo', async function () {
+        const res = await this.adminApi.sendAccountAdminInfo('/accounts/test.usd-ledger', { foo: 'bar' })
+        assert.deepEqual(res, {
+          account: 'test.usd-ledger',
+          plugin: 'ilp-plugin-mock',
+          result: {
+            foo: {
+              foo: 'bar'
+            }
+          }
+        })
+      })
     })
   })
 })

--- a/test/mocks/mockPlugin.js
+++ b/test/mocks/mockPlugin.js
@@ -53,6 +53,18 @@ class MockPlugin extends EventEmitter {
   deregisterMoneyHandler (moneyHandler) {
     this._moneyHandler = null
   }
+
+  getAdminInfo () {
+    return {
+      foo: 'bar'
+    }
+  }
+
+  sendAdminInfo (obj) {
+    return {
+      foo: obj
+    }
+  }
 }
 
 MockPlugin.version = 2


### PR DESCRIPTION
Right now, the kinds of things that the Moneyd GUI can view at are pretty limited. We can only see the internals of the connector.

This feature allows us to look inside of the plugin and allow it to expose additional info and admin operations. It adds two optional functions to the plugin interface.

```ts
getAdminInfo (): Promise<object>
setAdminInfo (object): Promise<object> 
```

It also adds two endpoints to the connector's admin API.

```http
GET /accounts/:account_id
POST /accounts/:account_id
```

`getAdminInfo` resolves an object with information about the plugin's state. For an XRP plugin, for instance, it might return channel IDs and channel balances, along with overall XRP balance. You can get this information from the admin API. Moneyd GUI could display a nicely formatted interface for plugins it knows about, and could dump the raw JSON for plugins it doesn't recognize.

`setAdminInfo` allows a JSON object to be passed into the plugin, and comes back with a result. For an XRP plugin, you could use this to manually trigger a channel fund or a settlement to a child (in the case of asym-server). It would make server plugins in general a lot less opaque. Moneyd GUI could display forms and buttons for plugins it knows about, or allow users to write raw JSON to send to plugins that Moneyd GUI doesn't recognize.

This change is non-breaking, but adds fields to existing admin API responses.