### PR TITLE
Retain ConnectorLogger `this` context

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -132,7 +132,7 @@ export default function createApp (opts?: object, container?: reduct.Injector) {
   } catch (err) {
     if (err.name === 'InvalidJsonBodyError') {
       log.warn('config validation error.')
-      err.debugPrint(log.warn)
+      err.debugPrint(log.warn.bind(log))
       log.error('invalid configuration, shutting down.')
       throw new Error('failed to initialize due to invalid configuration.')
     }

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -128,7 +128,7 @@ export default class Accounts extends EventEmitter {
     } catch (err) {
       if (err.name === 'InvalidJsonBodyError') {
         log.error('validation error in account config. id=%s', accountId)
-        err.debugPrint(log.warn)
+        err.debugPrint(log.warn.bind(log))
         throw new Error('error while adding account, see error log for details.')
       }
 


### PR DESCRIPTION
When you pass `log.warn` as a parameter to `debugPrint`, it then becomes an anonymous function as a variable and looses it's `this` context decoupling it away from `ConnectorLogger.prototype.warn`. Passing `log.warn.bind(log)` will retain the log's `this` context.

> **Example:**
[`https://repl.it/@roblav96/ilp-connector-logger-undefined-this`](https://repl.it/@roblav96/ilp-connector-logger-undefined-this)
