### PR TITLE
fix: stats memory leak

### DIFF
--- a/src/middlewares/stats.ts
+++ b/src/middlewares/stats.ts
@@ -65,9 +65,9 @@ export default class StatsMiddleware implements Middleware {
             this.stats.outgoingDataPackets.increment(account, { result: 'fulfilled' })
           } else {
             const rejectPacket = IlpPacket.deserializeIlpReject(result)
-            const { code, triggeredBy } = rejectPacket
+            const { code } = rejectPacket
             this.stats.outgoingDataPackets.increment(account,
-              { result: 'rejected', code, triggeredBy })
+              { result: 'rejected', code })
           }
           return result
         } catch (err) {

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -19,7 +19,7 @@ export class AccountCounter extends Prometheus.Counter {
   }
 }
 
-export class AccountGuage extends Prometheus.Gauge {
+export class AccountGauge extends Prometheus.Gauge {
   constructor (configuration: Prometheus.GaugeConfiguration) {
     configuration.labelNames = (configuration.labelNames || [])
     configuration.labelNames.push('account', 'asset', 'scale')
@@ -34,29 +34,29 @@ export default class Stats {
   public incomingDataPackets = new AccountCounter({
     name: 'ilp_connector_incoming_ilp_packets',
     help: 'Total number of incoming ILP packets',
-    labelNames: [ 'result', 'code' , 'triggeredBy'] })
+    labelNames: [ 'result', 'code'] })
 
   public incomingDataPacketValue = new AccountCounter({
     name: 'ilp_connector_incoming_ilp_packet_value',
     help: 'Total value of incoming ILP packets',
-    labelNames: [ 'result', 'code' , 'triggeredBy'] })
+    labelNames: [ 'result', 'code'] })
 
   public outgoingDataPackets = new AccountCounter({
     name: 'ilp_connector_outgoing_ilp_packets',
     help: 'Total number of outgoing ILP packets',
-    labelNames: [ 'result', 'code', 'triggeredBy' ] })
+    labelNames: [ 'result', 'code' ] })
 
   public outgoingDataPacketValue = new AccountCounter({
     name: 'ilp_connector_outgoing_ilp_packet_value',
     help: 'Total value of outgoing ILP packets',
-    labelNames: [ 'result', 'code', 'triggeredBy' ] })
+    labelNames: [ 'result', 'code' ] })
 
-  public incomingMoney = new AccountGuage({
+  public incomingMoney = new AccountGauge({
     name: 'ilp_connector_incoming_money',
     help: 'Total of incoming money',
     labelNames: [ 'result' ] })
 
-  public outgoingMoney = new AccountGuage({
+  public outgoingMoney = new AccountGauge({
     name: 'ilp_connector_outgoing_money',
     help: 'Total of outgoing money',
     labelNames: [ 'result' ] })
@@ -69,7 +69,7 @@ export default class Stats {
     name: 'ilp_connector_rate_limited_money',
     help: 'Total of rate limited money requests' })
 
-  public balance = new AccountGuage({
+  public balance = new AccountGauge({
     name: 'ilp_connector_balance',
     help: 'Balances on peer account' })
 


### PR DESCRIPTION
Labelling metrics with `triggeredBy` causes a memory leak because there are an unbounded number of ILP addresses that may be saved in memory.

Also fixes a typo: `s/AccountGuage/AccountGauge`.