### PR TITLE
chore: reenable integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,7 @@ test:
     - npm run lint
     - XUNIT_FILE=${CIRCLE_TEST_REPORTS}/mocha.xml npm test --coverage -- -R spec-xunit-file
     # Run integration test suite
-    # TODO: Re-enable integration tests once they are updated for ILPv4
-    # - if git log -1 --pretty=%B | grep -qF "[skip tests]"; then true; else npm run integration; fi
+    - if git log -1 --pretty=%B | grep -qF "[skip tests]"; then true; else npm run integration; fi
   post:
     - npm run report-coverage
 deployment:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "tslint --project . && eslint test/",
     "test": "nyc mocha",
     "report-coverage": "nyc report --reporter=json && codecov -f coverage/*.json",
-    "integration": "integration-loader && integration all",
+    "integration": "integration-loader && integration all -- --exit",
     "commitmsg": "commitlint -e $GIT_PARAMS"
   },
   "engines": {


### PR DESCRIPTION
Re enable the integration tests now that the integration tests have been moved to use ILPv4 with STREAM