### PR TITLE
feat: broaden scope of backend service

### DIFF
--- a/src/controllers/ilp-prepare.ts
+++ b/src/controllers/ilp-prepare.ts
@@ -47,6 +47,18 @@ export default class IlpPrepareController {
     log.trace('sending outbound ilp prepare. destination=%s amount=%s', destination, nextHopPacket.amount)
     const result = await outbound(IlpPacket.serializeIlpPrepare(nextHopPacket), nextHop)
 
+    this.backend.submitPacket({
+      sourceAccount: sourceAccount,
+      sourceAmount: amount,
+      destinationAccount: nextHop,
+      destinationAmount: nextHopPacket.amount,
+      parsedPacket,
+      result
+    }).catch(err => {
+      const errInfo = (err && typeof err === 'object' && err.stack) ? err.stack : String(err)
+      log.error('error while submitting packet to backend. error=%s', errInfo)
+    })
+
     if (result[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
       log.trace('got fulfillment. cond=%s nextHop=%s amount=%s', executionCondition.slice(0, 6).toString('base64'), nextHop, nextHopPacket.amount)
 

--- a/src/services/rate-backend.ts
+++ b/src/services/rate-backend.ts
@@ -23,7 +23,8 @@ export default class RateBackend implements BackendInstance {
     this.backend = new Backend(Object.assign({
       spread: config.spread
     }, config.backendConfig), {
-      getInfo: (account: string) => this.accounts.getInfo(account)
+      getInfo: (account: string) => this.accounts.getInfo(account),
+      accounts: this.accounts
     })
   }
 
@@ -37,6 +38,13 @@ export default class RateBackend implements BackendInstance {
 
   submitPayment (params: SubmitPaymentParams) {
     return this.backend.submitPayment(params)
+  }
+
+  submitPacket (params: SubmitPaymentParams) {
+    if (this.backend.submitPacket) {
+      return this.backend.submitPacket(params)
+    }
+    return Promise.resolve()
   }
 
   async getStatus () {

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -1,15 +1,20 @@
+import Accounts from '../services/accounts'
 import { AccountInfo } from '../types/accounts'
+import * as IlpPacket from 'ilp-packet'
 
 export interface SubmitPaymentParams {
   sourceAccount: string
   destinationAccount: string
   sourceAmount: string
   destinationAmount: string
+  parsedPacket?: IlpPacket.IlpPrepare
+  result?: Buffer
 }
 
 /** API exposed by the connector to its backends */
 export interface BackendServices {
   getInfo: (accountId: string) => AccountInfo | undefined
+  accounts?: Accounts
 }
 
 export interface BackendConstructor {
@@ -20,4 +25,5 @@ export interface BackendInstance {
   connect (): Promise<void>
   getRate (sourceAccount: string, destinationAccount: string): Promise<number>
   submitPayment (params: SubmitPaymentParams): Promise<void>
+  submitPacket? (params: SubmitPaymentParams): Promise<void>
 }


### PR DESCRIPTION
- `controllers/ilp-prepare` - change `submitPayment` to `submitPacket`: always submit to backend whether packet type is fulfill, prepare, reject
- `types/backend` - add more params to `SubmitPaymentParams`: backend should receive more data
- `services/backend` - replace `this.getInfo` with `this.accounts`: backend should have access to more of the `accounts` api
- backends `ecb`, `one-to-one`, `randomizer`: update from using `this.getInfo` to `this.accounts`