### PR TITLE
Update typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8218,9 +8218,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
-      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -8231,16 +8231,17 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "tsutils": "^2.27.2"
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.0.tgz",
-          "integrity": "sha512-okPpdvdJr6mUGi2XzupC+irQxzwGLVaBzacFC14hjLv8NColXEsxsU+QaeuSSXpQUak5g2K0vQ7WjA1e8svczg==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
           "dev": true
         }
       }
@@ -8296,9 +8297,9 @@
       }
     },
     "tsutils": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.21.0.tgz",
-      "integrity": "sha512-zlOHTYtTwvTiKxUyAU8wiKzPpAgwZrGjb7AY18VUlxuCgBiTMVorIl5HjrCT8V64Hm34RI1BZITJMVQpBLMxVg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7059,9 +7059,9 @@
       }
     },
     "reduct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/reduct/-/reduct-3.2.0.tgz",
-      "integrity": "sha512-bEPbrYTAQb7zCxI6QT1Rp26FJqNMt6Dos5q5KqOPxN0g7Muk9DZodGt75lL3ko56k98H0wODfCthEQ1x0Ww3JQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/reduct/-/reduct-3.3.1.tgz",
+      "integrity": "sha512-1OaOZqNczCfns093pnxtvOqe/1fr758JIIHlQkBritMMm3O1aPiDA3Wmj5gDsQjsBqMKB7lYU0BaUHIqLbS5sA=="
     },
     "regenerator-runtime": {
       "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,12 @@
         "rimraf": "^2.5.2"
       }
     },
+    "@types/abstract-leveldown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
+      "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
+      "dev": true
+    },
     "@types/cli-color": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.29.tgz",
@@ -177,12 +183,29 @@
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-4.0.0.tgz",
       "integrity": "sha1-+/bAeDaVRr0V/6eLp/Py4XBIB2k=",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/levelup": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-3.1.0.tgz",
+      "integrity": "sha512-Y2SC5PskYsE8+dELuWLCMG+UcUrkhhIz5wV55yX73AAVqr3kDXLYlj6k/vuchXUt1L1b/P1Frt4Dcc3WmWcbLA==",
+      "dev": true,
+      "requires": {
+        "@types/abstract-leveldown": "*",
+        "@types/events": "*",
         "@types/node": "*"
       }
     },
@@ -214,9 +237,9 @@
       }
     },
     "@types/node": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",
-      "integrity": "sha512-zkYho6/4wZyX6o9UQ8rd0ReEaiEYNNCqYFIAACe2Tf9DrYlgzWW27OigYHnnztnnZQwVRpwWmZKegFmDpinIsA==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
+      "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -233,6 +256,15 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.10.0.tgz",
       "integrity": "sha512-mjEM5uxPvMYg8LLcnmHzMy2G7HFRv7aQtcKslpmHg8SIIQutnLpLfps+1soV2YBlVBFrskR+F6I+nBI9NTh49w==",
       "dev": true
+    },
+    "@types/sax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.0.1.tgz",
+      "integrity": "sha512-5O70hTAMd9zEOoHiDJ6lk/WvqQgH+aIqU6zkvPLKIl6WJkQeHecHRUWomkjQzAAYPG346nDNus7y724FzTwTKQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/source-map-support": {
       "version": "0.4.0",
@@ -2447,16 +2479,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2469,20 +2499,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2574,7 +2601,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -2583,7 +2610,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -2599,8 +2626,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2612,9 +2638,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -2627,9 +2652,8 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2682,9 +2706,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2711,8 +2735,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -2727,8 +2751,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2746,8 +2770,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2781,8 +2804,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2803,10 +2826,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2880,11 +2903,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2893,7 +2915,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -2901,7 +2923,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -8318,9 +8340,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "sinon": "^4.1.3",
     "spec-xunit-file": "0.0.1-3",
     "ts-node": "^4.1.0",
-    "tslint": "^5.8.0",
+    "tslint": "^5.13.1",
     "tslint-config-standard": "^7.0.0",
     "typescript": "^3.3.3333",
     "unified": "^6.1.6"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-fetch": "^2.0.0",
     "oer-utils": "^4.0.0",
     "prom-client": "^11.1.1",
-    "reduct": "^3.2.0",
+    "reduct": "^3.3.1",
     "riverpig": "^1.1.4",
     "sax": "^1.2.4",
     "source-map-support": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,12 @@
     "@commitlint/config-conventional": "^6.1.0",
     "@justmoon/json-schema-to-markdown": "^1.0.0",
     "@types/debug": "0.0.30",
+    "@types/levelup": "^3.1.0",
     "@types/lodash": "^4.14.91",
     "@types/long": "^3.0.32",
-    "@types/node": "^9.4.0",
+    "@types/node": "^11.10.5",
     "@types/node-fetch": "^1.6.7",
+    "@types/sax": "^1.0.1",
     "@types/source-map-support": "^0.4.0",
     "@types/through2": "^2.0.33",
     "chai": "^4.1.2",
@@ -102,7 +104,7 @@
     "ts-node": "^4.1.0",
     "tslint": "^5.8.0",
     "tslint-config-standard": "^7.0.0",
-    "typescript": "^2.6.2",
+    "typescript": "^3.3.3333",
     "unified": "^6.1.6"
   },
   "config": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,6 @@ import Store from './services/store'
 import MiddlewareManager from './services/middleware-manager'
 import AdminApi from './services/admin-api'
 import * as Prometheus from 'prom-client'
-import { PluginInstance } from './types/plugin'
 
 const version = require('../package.json').version
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import reduct = require('reduct')
+import reduct, { Injector } from 'reduct'
 import { partial } from 'lodash'
 import { create as createLogger } from './common/log'
 const log = createLogger('app')
@@ -121,7 +121,7 @@ function shutdown (
   return accounts.disconnect()
 }
 
-export default function createApp (opts?: object, container?: reduct.Injector) {
+export default function createApp (opts?: object, container?: Injector) {
   const deps = container || reduct()
 
   const config = deps(Config)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -92,6 +92,11 @@ export function uuid () {
 
 export function hmac (secret: Buffer, message: string | Buffer) {
   const hmac = createHmac('sha256', secret)
-  hmac.update(message, 'utf8')
+  if (message instanceof Buffer) {
+    hmac.update(message)
+  } else {
+    hmac.update(message, 'utf8')
+  }
+
   return hmac.digest()
 }

--- a/src/middlewares/deduplicate.ts
+++ b/src/middlewares/deduplicate.ts
@@ -40,7 +40,7 @@ export default class DeduplicateMiddleware implements Middleware {
       packetLifetime: DEFAULT_PACKET_LIFETIME
     }
 
-    let interval
+    let interval: NodeJS.Timer
     pipelines.startup.insertLast({
       name: 'deduplicate',
       method: async (dummy: void, next: MiddlewareCallback<void, void>) => {

--- a/src/middlewares/expire.ts
+++ b/src/middlewares/expire.ts
@@ -16,7 +16,7 @@ export default class ExpireMiddleware implements Middleware {
 
           const promise = next(data)
 
-          let timeout
+          let timeout: NodeJS.Timer
           const timeoutPromise: Promise<Buffer> = new Promise((resolve, reject) => {
             timeout = setTimeout(() => {
               log.debug('packet expired. cond=%s expiresAt=%s', executionCondition.slice(0, 6).toString('base64'), expiresAt.toISOString())

--- a/src/middlewares/rate-limit.ts
+++ b/src/middlewares/rate-limit.ts
@@ -29,11 +29,14 @@ export default class RateLimitMiddleware implements Middleware {
     if (!accountInfo) {
       throw new Error('could not load info for account. accountId=' + accountId)
     }
+
+    const rateLimit = accountInfo.rateLimit || {}
     const {
       refillPeriod = DEFAULT_REFILL_PERIOD,
-      refillCount = DEFAULT_REFILL_COUNT,
-      capacity = refillCount
-    } = accountInfo.rateLimit || {}
+      refillCount = DEFAULT_REFILL_COUNT
+    } = rateLimit
+
+    const capacity = rateLimit.capacity || refillCount
 
     log.trace('created token bucket for account. accountId=%s refillPeriod=%s refillCount=%s capacity=%s', accountId, refillPeriod, refillCount, capacity)
 

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -192,7 +192,6 @@ export default class AdminApi {
     if (!middleware) return {}
     const alertMiddleware = middleware as AlertMiddleware
     if (!url) throw new Error('no path on request')
-    const urlPath = (url && url.split('?')[0]) || ''
     const match = /^\/alerts\/(\d+)$/.exec(url.split('?')[0])
     if (!match) throw new Error('invalid alert id')
     alertMiddleware.dismissAlert(+match[1])

--- a/src/stores/leveldown.ts
+++ b/src/stores/leveldown.ts
@@ -23,9 +23,14 @@ class LeveldownStore implements StoreInstance {
     this.db = levelup(leveldown(path))
   }
 
-  async get (key: string) {
+  async get (key: string): Promise<string | undefined> {
     try {
-      return (await this.db.get(key)).toString('utf8')
+      const value = await this.db.get(key) as Buffer | string
+      if (value instanceof Buffer) {
+        return value.toString('utf8')
+      } else {
+        return value
+      }
     } catch (e) {
       if (e.name !== 'NotFoundError') {
         throw e

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,13 @@
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "removeComments": true,
     "moduleResolution": "node",
     "inlineSources": true,
     "strict": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "skipLibCheck": true
   },
   "include": [
       "src/**/*.ts"


### PR DESCRIPTION
Closes https://github.com/interledgerjs/ilp-connector/issues/480

This fixes errors when importing ILP Connector to the latest version of typescript. Also makes the type checking stricter by enabling `noImplicitAny`

This doesn't break anything if you're still importing from typescript 2.6