### PR TITLE
Add `CONNECTOR_ADMIN_API=true` to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ https://www.techrepublic.com/blog/data-center/syncing-time-in-linux-and-windows-
 
 ```sh
 npm install -g ilp-connector ilp-plugin-btp
-CONNECTOR_STORE_PATH=~/.connector-data CONNECTOR_ACCOUNTS='{}' CONNECTOR_ILP_ADDRESS=test.quickstart ilp-connector
+CONNECTOR_STORE_PATH=~/.connector-data CONNECTOR_ACCOUNTS='{}' CONNECTOR_ADMIN_API=true CONNECTOR_ILP_ADDRESS=test.quickstart ilp-connector
 ```
 
 You are now running a connector!


### PR DESCRIPTION
The current Quickstart command is broken because the Connector does not stay running after issuing it.

This PR fixes this by enabling the AdminApi for this specific use-case. Without this additional directive, and because no accounts are defined in this quickstart command, there's nothing on the connector that's listening (no accounts and no admin API) and so there's nothing to keep the node process alive. With the admin API enabled it's running an http server, which will hold the connector process open.