### PR TITLE
Merge Prometheus ILP metrics with default metrics

### DIFF
--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -199,7 +199,10 @@ export default class AdminApi {
   }
 
   private async getMetrics () {
-    return Prometheus.register.metrics()
+    const promRegistry = Prometheus.register
+    const ilpRegistry = this.stats.getRegistry()
+    const mergedRegistry = Prometheus.Registry.merge([promRegistry, ilpRegistry])
+    return mergedRegistry.metrics()
   }
 
   private _getPlugin (url: string | undefined) {

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -109,4 +109,8 @@ export default class Stats {
   getStatus () {
     return this.registry.getMetricsAsJSON()
   }
+
+  getRegistry() {
+    return this.registry
+  }
 }

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -110,7 +110,7 @@ export default class Stats {
     return this.registry.getMetricsAsJSON()
   }
 
-  getRegistry() {
+  getRegistry () {
     return this.registry
   }
 }


### PR DESCRIPTION
As discussed on Slack, this is a PR to merge the metrics from the Prometheus ILP registry with the default registry and export it via the endpoint `/metrics`.

Prior to v22.2.0, the metrics export via `/metrics` used the Prometheus default registry that contains both metrics (ILP and nodejs/process) while >22.2.0 creates its own registry for the ILP metrics. This additional registry is only exported as JSON via the `/stats` endpoint, but not via `/metrics` anymore.