### PR TITLE
chore(circleci): try to fix docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run: git config --global user.name "CircleCI"
       - run: git config --global push.default simple
       - run: node scripts/publish_web.js
+      - setup_remote_docker
       - run: ./scripts/ci-deploy.sh
 
 


### PR DESCRIPTION
From circleci:

```
+ docker build -t interledger/js-ilp-connector --rm=false .
ERRO[0001] failed to dial gRPC: cannot connect to the Docker daemon. Is 'docker daemon' running on this host?: dial unix /var/run/docker.sock: connect: no such file or directory
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Exited with code 1
```