### PR TITLE
fix(balance)

### DIFF
--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -335,13 +335,8 @@ describe('Middleware Manager', function () {
           destination: 'mock.test3.bob',
           data: Buffer.alloc(0)
         })
-        const fulfillPacket = IlpPacket.serializeIlpFulfill({
-          fulfillment: Buffer.from('HS8e5Ew02XKAglyus2dh2Ohabuqmy3HDM8EXMLz22ok', 'base64'),
-          data: Buffer.alloc(0)
-        })
 
-        sinon.stub(this.mockPlugin3Wrapped, 'sendData')
-          .resolves(fulfillPacket)
+        sinon.stub(this.mockPlugin3Wrapped, 'sendData').throws()
 
         await this.middlewareManager.setup()
         const result = await this.mockPlugin1Wrapped._dataHandler(preparePacket)


### PR DESCRIPTION
Currently there is a serious bug in the balance logic due to the way minimum balance works. Packets will be forwarded to an outgoing peer and only on the fulfil will we check if the balance exceeds the minimum for that peer (in the subtract logic). If it does we then throw an error and reject the packet downstream. However we have already sent the prepare and received a fulfil and have thus lost money as we owe our outgoing peer.

The solution proposed though changes the balance to be symmetrically tracked which I know @justmoon said shouldn't be necessary. Though I am not sure how else you enforce the minimum criteria without atomically changing the balance before forwarding it to your outgoing peer.