### PR TITLE
chore: pass options

### DIFF
--- a/examples/example-using-LPI-v2.js
+++ b/examples/example-using-LPI-v2.js
@@ -22,7 +22,7 @@ launch('ilp-plugin-mirror').then(connector => {
   connector.getPlugin('bob').mirror.registerMoneyHandler(amount => {
     console.log('money showed up at bob!', amount)
   })
-  connector.getPlugin('bob').mirror.sendData(Ildcp.serializeIldcpRequest()).then(fulfill => {
+  connector.getPlugin('bob').mirror.sendData(Ildcp.serializeIldcpRequest({})).then(fulfill => {
     const bobInfo = Ildcp.deserializeIldcpResponse(fulfill)
     const prepare = IlpPacket.serializeIlpPrepare({
       amount: '10',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "copy-schemas": "cpy 'src/schemas/*.json' dist/schemas",
     "prepack": "npm run build",
     "lint": "tslint --project . && eslint test/*.test.js test/mocks/ test/helpers/",
-    "test": "npm build && nyc mocha",
+    "test": "npm run build && nyc mocha",
     "report-coverage": "codecov",
     "integration": "integration-loader && integration all",
     "commitmsg": "commitlint -e $GIT_PARAMS"


### PR DESCRIPTION
Fixes https://github.com/interledgerjs/ilp-connector/issues/500

`ilp-protocol-ildcp`'s `serializeIldcpRequest` requires an options object.